### PR TITLE
cast mjpeg data pointer to unsigned char. some compilers don't accept…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ include_directories(
 if(JPEG_FOUND)
   message(STATUS "Building libuvc with JPEG support.")
   include_directories(${JPEG_INCLUDE_DIR})
-  SET(LIBUVC_HAS_JPEG TRUE)
+  #set actual definition, so the necessary function in frame-mjpeg is defined
+  ADD_DEFINITIONS(-DLIBUVC_HAS_JPEG)
   SET(SOURCES ${SOURCES} src/frame-mjpeg.c)
 else()
   message(WARNING "JPEG not found. libuvc will not support JPEG decoding.")

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -470,7 +470,7 @@ typedef struct uvc_stream_ctrl {
 uvc_error_t uvc_init(uvc_context_t **ctx, struct libusb_context *usb_ctx);
 void uvc_exit(uvc_context_t *ctx);
 
-uvc_error_t uvc_get_device_list(
+int uvc_get_device_list(
     uvc_context_t *ctx,
     uvc_device_t ***list);
 void uvc_free_device_list(uvc_device_t **list, uint8_t unref_devices);

--- a/src/device.c
+++ b/src/device.c
@@ -556,9 +556,9 @@ void uvc_free_device_descriptor(
  *
  * @param ctx UVC context in which to list devices
  * @param list List of uvc_device structures
- * @return Error if unable to list devices, else SUCCESS
+ * @return number of detected uvc devices
  */
-uvc_error_t uvc_get_device_list(
+int uvc_get_device_list(
     uvc_context_t *ctx,
     uvc_device_t ***list) {
   uvc_error_t ret;
@@ -658,7 +658,7 @@ uvc_error_t uvc_get_device_list(
   *list = list_internal;
 
   UVC_EXIT(UVC_SUCCESS);
-  return UVC_SUCCESS;
+  return num_uvc_devices;
 }
 
 /**

--- a/src/frame-mjpeg.c
+++ b/src/frame-mjpeg.c
@@ -170,7 +170,7 @@ uvc_error_t uvc_mjpeg2rgb(uvc_frame_t *in, uvc_frame_t *out) {
 
   lines_read = 0;
   while (dinfo.output_scanline < dinfo.output_height) {
-    unsigned char *buffer[1] = { out->data + lines_read * out->step };
+    unsigned char *buffer[1] = { (unsigned char*)out->data + lines_read * out->step };
     int num_scanlines;
 
     num_scanlines = jpeg_read_scanlines(&dinfo, buffer, 1);


### PR DESCRIPTION
A void pointer is not accepted by e.g. msvc14 to set data buffer. Use cast to unsigned char pointer.

Add pre-processor definition so that mjpeg conversion function is actually declared. A cmake set won't influence the ifdef used to declare the uvc_mjpeg2rgb function in libuvc.h

change the uvc_get_device_list function return value to the actual uvc device count. This enables direct list iteration. The error return code is also preserved.
