### PR TITLE
libusb.h to libusb-1.0/libusb.h

### DIFF
--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 #include <stdio.h> // FILE
-#include <libusb.h>
+#include <libusb-1.0/libusb.h>
 #include <libuvc/libuvc_config.h>
 
 /** UVC error types, based on libusb errors


### PR DESCRIPTION
My libusb from Ubuntu 16.04.1 repository is installed under the following folders by default:

```
/usr/include/libusb-1.0/libusb.h
/usr/lib/x86_64-linux-gnu/libusb-1.0.so
```

So, shall we just replace 
libusb.h
to
libusb-1.0/libusb.h ???

Cheers
Pei
