### PR TITLE
Add package xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ export(TARGETS uvc
   FILE "${PROJECT_BINARY_DIR}/libuvcTargets.cmake")
 export(PACKAGE libuvc)
 
-set(CONF_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
+set(CONF_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include;${LIBUSB_INCLUDE_DIRS}")
 set(CONF_LIBRARY "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}uvc${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
 configure_file(libuvcConfig.cmake.in ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libuvcConfig.cmake)

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>libuvc</name>
+  <version>0.0.5</version>
+  <description>UVC</description>
+
+  <maintainer email="ken@tossell.net">Ken Tossell</maintainer>
+  <author email="ken@tossell.net">Ken Tossell</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>libusb-1.0-dev</build_depend>
+
+  <exec_depend>libusb-1.0</exec_depend>
+
+  <depend>libjpeg</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
@ktossell This allows to create a workspace and run `catkin build`.

`LIBUSB_INCLUDE_DIRS` needs to be exported, so `libuvc_camera` can build on the same workspace.
I think this issue didn't happen with the system-wise installation of `libuvc` because it puts `libuvc` in the same place as `libusb-1.0`.
