### PR TITLE
Feature/improved cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(libuvc_VERSION_PATCH 5)
 set(libuvc_VERSION ${libuvc_VERSION_MAJOR}.${libuvc_VERSION_MINOR}.${libuvc_VERSION_PATCH})
 
 find_package(PkgConfig)
-pkg_check_modules(LIBUSB libusb-1.0)
+pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
 
 # Try to find JPEG using a module or pkg-config. If that doesn't work, search for the header.
 find_package(jpeg QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 SET(CMAKE_C_FLAGS_DEBUG "-g -DUVC_DEBUGGING")
 
 SET(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake/libuvc" CACHE PATH
-	"Installation directory for CMake files")
+  "Installation directory for CMake files")
 
 SET(SOURCES src/ctrl.c src/ctrl-gen.c src/device.c src/diag.c
            src/frame.c src/init.c src/stream.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,18 +31,32 @@ endif()
 
 SET(CMAKE_C_FLAGS_DEBUG "-g -DUVC_DEBUGGING")
 
-SET(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake/libuvc" CACHE PATH
+# Offer the user the choice of overriding the installation directories
+SET(INSTALL_INCLUDE_DIR include CACHE PATH
+  "Installation directory for header files")
+SET(INSTALL_CMAKE_DIR lib/cmake/libuvc CACHE PATH
   "Installation directory for CMake files")
 
-SET(SOURCES src/ctrl.c src/ctrl-gen.c src/device.c src/diag.c
-           src/frame.c src/init.c src/stream.c
-           src/misc.c)
+# Create absolute versions of install paths (needed later on)
+foreach(p INCLUDE CMAKE)
+  set(var INSTALL_${p}_DIR)
+  set(ABS_${var} ${${var}})  # i.e. ABS_INSTALL_INCLUDE_DIR
+  if(NOT IS_ABSOLUTE "${${var}}")
+    set(ABS_${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  endif()
+endforeach()
 
+# Set up include-directories
 include_directories(
   ${libuvc_SOURCE_DIR}/include
   ${libuvc_BINARY_DIR}/include
   ${LIBUSB_INCLUDE_DIRS}
 )
+
+# Configure the uvc library
+SET(SOURCES src/ctrl.c src/ctrl-gen.c src/device.c src/diag.c
+           src/frame.c src/init.c src/stream.c
+           src/misc.c)
 
 if(JPEG_FOUND)
   message(STATUS "Building libuvc with JPEG support.")
@@ -62,10 +76,10 @@ else()
 endif()
 
 configure_file(include/libuvc/libuvc_config.h.in
-  ${PROJECT_BINARY_DIR}/include/libuvc/libuvc_config.h @ONLY)
+  "${CMAKE_CURRENT_BINARY_DIR}/include/libuvc/libuvc_config.h" @ONLY)
 
 set_target_properties(uvc PROPERTIES
-  PUBLIC_HEADER "include/libuvc/libuvc.h;${libuvc_BINARY_DIR}/include/libuvc/libuvc_config.h" )
+  PUBLIC_HEADER "include/libuvc/libuvc.h;${CMAKE_CURRENT_BINARY_DIR}/include/libuvc/libuvc_config.h")
 
 if(JPEG_FOUND)
   target_link_libraries (uvc ${JPEG_LIBRARIES})
@@ -78,27 +92,42 @@ target_link_libraries(uvc ${LIBUSB_LIBRARIES})
 #  opencv_core)
 
 install(TARGETS uvc
+  # IMPORTANT: Add the uvc library to the "export-set"
   EXPORT libuvcTargets
-  LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
-  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_PREFIX}/include/libuvc"
+  LIBRARY DESTINATION lib COMPONENT shlib
+  ARCHIVE DESTINATION lib COMPONENT lib
+  PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/libuvc" COMPONENT dev
 )
 
+# Add all targets to the build-tree export set
 export(TARGETS uvc
   FILE "${PROJECT_BINARY_DIR}/libuvcTargets.cmake")
+
+# Export the package for use from the build-tree
+# (this registers the build-tree with a global CMake-registry)
 export(PACKAGE libuvc)
 
-set(CONF_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
-set(CONF_LIBRARY "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}uvc${CMAKE_SHARED_LIBRARY_SUFFIX}")
+# Create the libuvcConfig.cmake and libuvcConfigVersion.cmake files
+file(RELATIVE_PATH REL_INCLUDE_DIR "${ABS_INSTALL_CMAKE_DIR}"
+  "${ABS_INSTALL_INCLUDE_DIR}")
+# ... for the build tree
+set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
+configure_file(libuvcConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/libuvcConfig.cmake" @ONLY)
+# ... for the install tree
+set(CONF_INCLUDE_DIRS "\${libuvc_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+configure_file(libuvcConfig.cmake.in
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libuvcConfig.cmake" @ONLY)
+# ... for both
+configure_file(libuvcConfigVersion.cmake.in
+  "${PROJECT_BINARY_DIR}/libuvcConfigVersion.cmake" @ONLY)
 
-configure_file(libuvcConfig.cmake.in ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libuvcConfig.cmake)
-
-configure_file(libuvcConfigVersion.cmake.in ${PROJECT_BINARY_DIR}/libuvcConfigVersion.cmake @ONLY)
-
+# Install the libuvcConfig.cmake and libuvcConfigVersion.cmake files
 install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libuvcConfig.cmake"
   "${PROJECT_BINARY_DIR}/libuvcConfigVersion.cmake"
-  DESTINATION "${INSTALL_CMAKE_DIR}")
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
 
+# Install the export-set for use with the install-tree
 install(EXPORT libuvcTargets
-  DESTINATION "${INSTALL_CMAKE_DIR}")
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)

--- a/libuvcConfig.cmake.in
+++ b/libuvcConfig.cmake.in
@@ -1,3 +1,16 @@
 # - Config file for the libuvc package
-set(libuvc_INCLUDE_DIRS "@CONF_INCLUDE_DIR@")
-set(libuvc_LIBRARIES "@CONF_LIBRARY@")
+# It defines the following variables
+#  libuvc_INCLUDE_DIRS - include directories for libuvc
+#  libuvc_LIBRARIES    - libraries to link against
+
+# Compute paths
+get_filename_component(libuvc_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(libuvc_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+
+# Our library dependencies (contains definitions for IMPORTED targets)
+if(NOT TARGET uvc AND NOT libuvc_BINARY_DIR)
+  include("${libuvc_CMAKE_DIR}/libuvcTargets.cmake")
+endif()
+
+# These are IMPORTED targets created by libuvcTargets.cmake
+set(libuvc_LIBRARIES uvc)


### PR DESCRIPTION
I noticed `libuvcConfig.cmake` was using absolute paths!  This branch replaces those paths with relative ones and properly includes the generated `libuvcTargets*.cmake` files.  I followed the CMake tutorial on ["How to create a Project Config"](https://cmake.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file), as the existing CMakeLists.txt followed that template closely to begin with.

My devenv is Ubuntu 14.04, CMake 3.7.0.