### PR TITLE
Add method 2 (in stream) still capture support

### DIFF
--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -120,6 +120,28 @@ enum uvc_vs_desc_subtype {
 struct uvc_format_desc;
 struct uvc_frame_desc;
 
+typedef struct uvc_still_frame_res {
+  struct uvc_still_frame_res *prev, *next;
+  uint8_t bResolutionIndex;
+  /** Image width */
+  uint16_t wWidth;
+  /** Image height */
+  uint16_t wHeight;
+} uvc_still_frame_res_t;
+
+typedef struct uvc_still_frame_desc {
+  struct uvc_format_desc *parent;
+  struct uvc_still_frame_desc *prev, *next;
+  /** Type of frame, such as JPEG frame or uncompressed frme */
+  enum uvc_vs_desc_subtype bDescriptorSubtype;
+  /** Index of the frame within the list of specs available for this format */
+  uint8_t bEndPointAddress;
+  uvc_still_frame_res_t* imageSizePatterns;
+  uint8_t bNumCompressionPattern;
+  /* indication of compression level, the higher, the more compression is applied to image */
+  uint8_t* bCompression;
+} uvc_still_frame_desc_t;
+
 /** Frame descriptor
  *
  * A "frame" is a configuration of a streaming format
@@ -194,6 +216,7 @@ typedef struct uvc_format_desc {
   uint8_t bVariableSize;
   /** Available frame specifications for this format */
   struct uvc_frame_desc *frame_descs;
+  struct uvc_still_frame_desc *still_frame_desc;
 } uvc_format_desc_t;
 
 /** UVC request code (A.8) */
@@ -480,6 +503,20 @@ typedef struct uvc_stream_ctrl {
   uint8_t bInterfaceNumber;
 } uvc_stream_ctrl_t;
 
+typedef struct uvc_still_ctrl {
+  /* Video format index from a format descriptor */
+  uint8_t bFormatIndex;
+  /* Video frame index from a frame descriptor */
+  uint8_t bFrameIndex;
+  /* Compression index from a frame descriptor */
+  uint8_t bCompressionIndex;
+  /* Maximum still image size in bytes. */
+  uint32_t dwMaxVideoFrameSize;
+  /* Maximum number of byte per payload*/
+  uint32_t dwMaxPayloadTransferSize;
+  uint8_t bInterfaceNumber;
+} uvc_still_ctrl_t;
+
 uvc_error_t uvc_init(uvc_context_t **ctx, struct libusb_context *usb_ctx);
 void uvc_exit(uvc_context_t *ctx);
 
@@ -541,11 +578,25 @@ uvc_error_t uvc_get_stream_ctrl_format_size(
     int fps
     );
 
+uvc_error_t uvc_get_still_ctrl_format_size(
+    uvc_device_handle_t *devh,
+    uvc_stream_ctrl_t *ctrl,
+    uvc_still_ctrl_t *still_ctrl,
+    int width, int height);
+
+uvc_error_t uvc_trigger_still(
+    uvc_device_handle_t *devh,
+    uvc_still_ctrl_t *still_ctrl);
+
 const uvc_format_desc_t *uvc_get_format_descs(uvc_device_handle_t* );
 
 uvc_error_t uvc_probe_stream_ctrl(
     uvc_device_handle_t *devh,
     uvc_stream_ctrl_t *ctrl);
+
+uvc_error_t uvc_probe_still_ctrl(
+    uvc_device_handle_t *devh,
+    uvc_still_ctrl_t *still_ctrl);
 
 uvc_error_t uvc_start_streaming(
     uvc_device_handle_t *devh,

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -172,6 +172,7 @@ typedef struct uvc_streaming_interface {
   /** USB endpoint to use when communicating with this interface */
   uint8_t bEndpointAddress;
   uint8_t bTerminalLink;
+  uint8_t bStillCaptureMethod;
 } uvc_streaming_interface_t;
 
 /** VideoControl interface */

--- a/src/device.c
+++ b/src/device.c
@@ -415,6 +415,8 @@ void uvc_free_device_info(uvc_device_info_t *info) {
   uvc_streaming_interface_t *stream_if, *stream_if_tmp;
   uvc_format_desc_t *format, *format_tmp;
   uvc_frame_desc_t *frame, *frame_tmp;
+  uvc_still_frame_desc_t *still_frame, *still_frame_tmp;
+  uvc_still_frame_res_t *still_res, *still_res_tmp;
 
   UVC_ENTER();
 
@@ -441,6 +443,19 @@ void uvc_free_device_info(uvc_device_info_t *info) {
 
         DL_DELETE(format->frame_descs, frame);
         free(frame);
+      }
+
+      if(format->still_frame_desc) {
+        DL_FOREACH_SAFE(format->still_frame_desc, still_frame, still_frame_tmp) {
+          DL_FOREACH_SAFE(still_frame->imageSizePatterns, still_res, still_res_tmp) {
+            free(still_res);
+          }
+
+          if(still_frame->bCompression) {
+              free(still_frame->bCompression);
+          }
+          free(still_frame);
+        }
       }
 
       DL_DELETE(stream_if->format_descs, format);
@@ -1245,6 +1260,7 @@ uvc_error_t uvc_parse_vs_input_header(uvc_streaming_interface_t *stream_if,
 
   stream_if->bEndpointAddress = block[6] & 0x8f;
   stream_if->bTerminalLink = block[8];
+  stream_if->bStillCaptureMethod = block[9];
 
   UVC_EXIT(UVC_SUCCESS);
   return UVC_SUCCESS;
@@ -1444,6 +1460,69 @@ uvc_error_t uvc_parse_vs_frame_uncompressed(uvc_streaming_interface_t *stream_if
 }
 
 /** @internal
+ * @brief Parse a VideoStreaming still iamge frame
+ * @ingroup device
+ */
+uvc_error_t uvc_parse_vs_still_image_frame(uvc_streaming_interface_t *stream_if,
+                        const unsigned char *block,
+                        size_t block_size) {
+
+  struct uvc_still_frame_desc* frame;
+  uvc_format_desc_t *format;
+
+  const unsigned char *p;
+  int i;
+
+  UVC_ENTER();
+
+  format = stream_if->format_descs->prev;
+  frame = calloc(1, sizeof(*frame));
+
+  frame->parent = format;
+
+  frame->bDescriptorSubtype = block[2];
+  frame->bEndPointAddress   = block[3];
+  uint8_t numImageSizePatterns = block[4];
+
+  frame->imageSizePatterns = NULL;
+
+  p = &block[5];
+
+  for (i = 1; i <= numImageSizePatterns; ++i) {
+    uvc_still_frame_res_t* res = calloc(1, sizeof(uvc_still_frame_res_t));
+    res->bResolutionIndex = i;
+    res->wWidth = SW_TO_SHORT(p);
+    p += 2;
+    res->wHeight = SW_TO_SHORT(p);
+    p += 2;
+
+    DL_APPEND(frame->imageSizePatterns, res);
+  }
+
+  p = &block[5+4*numImageSizePatterns];
+  frame->bNumCompressionPattern = *p;
+
+  if(frame->bNumCompressionPattern)
+  {
+      frame->bCompression = calloc(frame->bNumCompressionPattern, sizeof(frame->bCompression[0]));
+      for(i = 0; i < frame->bNumCompressionPattern; ++i)
+      {
+          ++p;
+          frame->bCompression[i] = *p;
+      }
+  }
+  else
+  {
+      frame->bCompression = NULL;
+  }
+
+  DL_APPEND(format->still_frame_desc, frame);
+
+  UVC_EXIT(UVC_SUCCESS);
+  return UVC_SUCCESS;
+}
+
+/** @internal
  * Process a single VideoStreaming descriptor block
  * @ingroup device
  */
@@ -1468,7 +1547,7 @@ uvc_error_t uvc_parse_vs(
     fprintf ( stderr, "unsupported descriptor subtype VS_OUTPUT_HEADER\n" );
     break;
   case UVC_VS_STILL_IMAGE_FRAME:
-    fprintf ( stderr, "unsupported descriptor subtype VS_STILL_IMAGE_FRAME\n" );
+    ret = uvc_parse_vs_still_image_frame(stream_if, block, block_size);
     break;
   case UVC_VS_FORMAT_UNCOMPRESSED:
     ret = uvc_parse_vs_format_uncompressed(stream_if, block, block_size);

--- a/src/diag.c
+++ b/src/diag.c
@@ -246,6 +246,27 @@ void uvc_print_diag(uvc_device_handle_t *devh, FILE *stream) {
                       10000000 / frame_desc->dwFrameIntervalStep);
               }
             }
+            if(fmt_desc->still_frame_desc)
+            {
+                uvc_still_frame_desc_t* still_frame_desc;
+                DL_FOREACH(fmt_desc->still_frame_desc, still_frame_desc)
+                {
+                    fprintf(stream,
+                        "\t\t\tStillFrameDescriptor\n"
+                        "\t\t\t  bEndPointAddress: %02x\n",
+                        still_frame_desc->bEndPointAddress);
+                    uvc_still_frame_res_t* imageSizePattern;
+                    DL_FOREACH(still_frame_desc->imageSizePatterns, imageSizePattern) {
+                        fprintf(stream,
+                            "\t\t\t  wWidth(%d) = %d\n"
+                            "\t\t\t  wHeight(%d) = %d\n",
+                            imageSizePattern->bResolutionIndex,
+                            imageSizePattern->wWidth,
+                            imageSizePattern->bResolutionIndex,
+                            imageSizePattern->wHeight);
+                    }
+                }
+            }
             break;
           default:
             fprintf(stream, "\t-UnknownFormat (%d)\n",


### PR DESCRIPTION
Hi!
I created code to allow still capture with higher resolution than streaming resolution.
It doesn't support method 3 though (on a separate endpoint) as my device supports only method 2 (in stream).

Because this feature is on your roadmap, I though you might be interested.