### PR TITLE
Add support for BGR frame format

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -103,9 +103,9 @@ struct format_table_entry *_get_format_entry(enum uvc_frame_format format) {
     ABS_FMT(UVC_FRAME_FORMAT_ANY, 2,
       {UVC_FRAME_FORMAT_UNCOMPRESSED, UVC_FRAME_FORMAT_COMPRESSED})
 
-    ABS_FMT(UVC_FRAME_FORMAT_UNCOMPRESSED, 5,
+    ABS_FMT(UVC_FRAME_FORMAT_UNCOMPRESSED, 6,
       {UVC_FRAME_FORMAT_YUYV, UVC_FRAME_FORMAT_UYVY, UVC_FRAME_FORMAT_GRAY8,
-      UVC_FRAME_FORMAT_GRAY16, UVC_FRAME_FORMAT_NV12})
+      UVC_FRAME_FORMAT_GRAY16, UVC_FRAME_FORMAT_NV12, UVC_FRAME_FORMAT_BGR})
     FMT(UVC_FRAME_FORMAT_YUYV,
       {'Y',  'U',  'Y',  '2', 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71})
     FMT(UVC_FRAME_FORMAT_UYVY,
@@ -116,6 +116,8 @@ struct format_table_entry *_get_format_entry(enum uvc_frame_format format) {
       {'Y',  '1',  '6',  ' ', 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71})
     FMT(UVC_FRAME_FORMAT_NV12,
       {'N',  'V',  '1',  '2', 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71})
+    FMT(UVC_FRAME_FORMAT_BGR,
+      {0x7d, 0xeb, 0x36, 0xe4, 0x4f, 0x52, 0xce, 0x11, 0x9f, 0x53, 0x00, 0x20, 0xaf, 0x0b, 0xa7, 0x70})
     FMT(UVC_FRAME_FORMAT_BY8,
       {'B',  'Y',  '8',  ' ', 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71})
     FMT(UVC_FRAME_FORMAT_BA81,
@@ -1323,6 +1325,9 @@ void _uvc_populate_frame(uvc_stream_handle_t *strmh) {
   frame->height = frame_desc->wHeight;
   
   switch (frame->frame_format) {
+  case UVC_FRAME_FORMAT_BGR:
+    frame->step = frame->width * 3;
+    break;
   case UVC_FRAME_FORMAT_YUYV:
     frame->step = frame->width * 2;
     break;


### PR DESCRIPTION
This strange-looking UVC format code is UVC_GUID_FORMAT_BGR3 used by
v4l2/uvc that you will get asking for the 'BGR' type in gstreamer
or guvcview.