### PR TITLE
Android support

### DIFF
--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -554,6 +554,13 @@ uvc_error_t uvc_find_devices(
     uvc_device_t ***devs,
     int vid, int pid, const char *sn);
 
+#if LIBUSB_API_VERSION >= 0x01000107
+uvc_error_t uvc_wrap(
+    int sys_dev,
+    uvc_context_t *context,
+    uvc_device_handle_t **devh);
+#endif
+
 uvc_error_t uvc_open(
     uvc_device_t *dev,
     uvc_device_handle_t **devh);

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -50,10 +50,18 @@
 
 #ifdef UVC_DEBUGGING
 #include <libgen.h>
+#ifdef __ANDROID__
+#include <android/log.h>
+#define UVC_DEBUG(format, ...) __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d/%s] " format "\n", basename(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__)
+#define UVC_ENTER() __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d] begin %s\n", basename(__FILE__), __LINE__, __FUNCTION__)
+#define UVC_EXIT(code) __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d] end %s (%d)\n", basename(__FILE__), __LINE__, __FUNCTION__, code)
+#define UVC_EXIT_VOID() __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d] end %s\n", basename(__FILE__), __LINE__, __FUNCTION__)
+#else
 #define UVC_DEBUG(format, ...) fprintf(stderr, "[%s:%d/%s] " format "\n", basename(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__)
 #define UVC_ENTER() fprintf(stderr, "[%s:%d] begin %s\n", basename(__FILE__), __LINE__, __FUNCTION__)
 #define UVC_EXIT(code) fprintf(stderr, "[%s:%d] end %s (%d)\n", basename(__FILE__), __LINE__, __FUNCTION__, code)
 #define UVC_EXIT_VOID() fprintf(stderr, "[%s:%d] end %s\n", basename(__FILE__), __LINE__, __FUNCTION__)
+#endif
 #else
 #define UVC_DEBUG(format, ...)
 #define UVC_ENTER()


### PR DESCRIPTION
Hey everyone.

Here are changes to support using libuvc on non-rooted android devices (might be useful elsewhere too).

Have added uvc_wrap() that is almost identical to uvc_open() and calls libusb_wrap_sys_device() instead of libusb_open().
Device file descriptor is easily retrieved from android USB apis.

Have included minimal [example code](https://github.com/libuvc/libuvc/blob/118b527af35b87b3c72e0c325f9c93608367a0cf/doc/android-example.md) (probably in wrong place).