### PR TITLE
uvc_stream_start: first call to libusb_submit_transfer can fail

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -1237,8 +1237,7 @@ uvc_error_t uvc_stream_start(
   }
 
   if ( ret != UVC_SUCCESS && transfer_id >= 0 ) {
-    for ( ; transfer_id < LIBUVC_NUM_TRANSFER_BUFS;
-        transfer_id++) {
+    for ( ; transfer_id < LIBUVC_NUM_TRANSFER_BUFS; transfer_id++) {
       free ( strmh->transfers[transfer_id]->buffer );
       libusb_free_transfer ( strmh->transfers[transfer_id]);
       strmh->transfers[transfer_id] = 0;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1236,8 +1236,9 @@ uvc_error_t uvc_stream_start(
     }
   }
 
-  if ( ret != UVC_SUCCESS && transfer_id > 0 ) {
-    for ( ; transfer_id < LIBUVC_NUM_TRANSFER_BUFS; transfer_id++) {
+  if ( ret != UVC_SUCCESS && transfer_id >= 0 ) {
+    for ( ; transfer_id < LIBUVC_NUM_TRANSFER_BUFS;
+        transfer_id++) {
       free ( strmh->transfers[transfer_id]->buffer );
       libusb_free_transfer ( strmh->transfers[transfer_id]);
       strmh->transfers[transfer_id] = 0;


### PR DESCRIPTION
was not entering the 'Clean up transfer buffers when an error occurs'
part when an error occurs with the first transfer (i.e. transfer_id == 0)