### PR TITLE
Compilation warnings bugfix

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -289,11 +289,11 @@ uvc_error_t uvc_wrap(
   UVC_ENTER();
 
   uvc_device_t *dev = NULL;
-  ret = libusb_wrap_sys_device(context->usb_ctx, sys_dev, &usb_devh);
-  UVC_DEBUG("libusb_wrap_sys_device() = %d", ret);
-  if (ret != LIBUSB_SUCCESS) {
-    UVC_EXIT(ret);
-    return ret;
+  int err = libusb_wrap_sys_device(context->usb_ctx, sys_dev, &usb_devh);
+  UVC_DEBUG("libusb_wrap_sys_device() = %d", err);
+  if (err != LIBUSB_SUCCESS) {
+    UVC_EXIT(err);
+    return err;
   }
 
   dev = calloc(1, sizeof(uvc_device_t));
@@ -1085,8 +1085,10 @@ uvc_error_t uvc_parse_vc_header(uvc_device_t *dev,
   switch (info->ctrl_if.bcdUVC) {
   case 0x0100:
     info->ctrl_if.dwClockFrequency = DW_TO_INT(block + 7);
+    break;
   case 0x010a:
     info->ctrl_if.dwClockFrequency = DW_TO_INT(block + 7);
+    break;
   case 0x0110:
     break;
   default:

--- a/src/stream.c
+++ b/src/stream.c
@@ -1381,7 +1381,6 @@ uvc_error_t uvc_stream_get_frame(uvc_stream_handle_t *strmh,
   time_t add_secs;
   time_t add_nsecs;
   struct timespec ts;
-  struct timeval tv;
 
   if (!strmh->running)
     return UVC_ERROR_INVALID_PARAM;
@@ -1407,6 +1406,7 @@ uvc_error_t uvc_stream_get_frame(uvc_stream_handle_t *strmh,
 #if _POSIX_TIMERS > 0
       clock_gettime(CLOCK_REALTIME, &ts);
 #else
+      struct timeval tv;
       gettimeofday(&tv, NULL);
       ts.tv_sec = tv.tv_sec;
       ts.tv_nsec = tv.tv_usec * 1000;


### PR DESCRIPTION
I introduced following changes in order to eliminate compiler warnings:
 
- comparing `uvc_error_t` with `int` (libusb return error value)
- Wimplicit-fallthrough
- Wunused-variable
