### PR TITLE
Memory usage optimization

### DIFF
--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -220,13 +220,13 @@ typedef struct uvc_device_info {
   avoids problems with scheduling delays on slow boards causing missed
   transfers. A better approach may be to make the transfer thread FIFO
   scheduled (if we have root).
-  We could/should change this to allow reduce it to, say, 5 by default
-  and then allow the user to change the number of buffers as required.
+  Default number of transfer buffers can be overwritten by defining
+  this macro.
  */
+#ifndef LIBUVC_NUM_TRANSFER_BUFS
 #define LIBUVC_NUM_TRANSFER_BUFS 100
+#endif
 
-#define LIBUVC_XFER_BUF_SIZE	( 16 * 1024 * 1024 )
-#define LIBUVC_XFER_META_BUF_SIZE ( 4 * 1024 )
 
 struct uvc_stream_handle {
   struct uvc_device_handle *devh;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1024,12 +1024,12 @@ uvc_error_t uvc_stream_open_ctrl(uvc_device_handle_t *devh, uvc_stream_handle_t 
 
   // Set up the streaming status and data space
   strmh->running = 0;
-  /** @todo take only what we need */
-  strmh->outbuf = malloc( LIBUVC_XFER_BUF_SIZE );
-  strmh->holdbuf = malloc( LIBUVC_XFER_BUF_SIZE );
 
-  strmh->meta_outbuf = malloc( LIBUVC_XFER_META_BUF_SIZE );
-  strmh->meta_holdbuf = malloc( LIBUVC_XFER_META_BUF_SIZE );
+  strmh->outbuf = malloc( ctrl->dwMaxVideoFrameSize );
+  strmh->holdbuf = malloc( ctrl->dwMaxVideoFrameSize );
+
+  strmh->meta_outbuf = malloc( ctrl->dwMaxVideoFrameSize );
+  strmh->meta_holdbuf = malloc( ctrl->dwMaxVideoFrameSize );
    
   pthread_mutex_init(&strmh->cb_mutex, NULL);
   pthread_cond_init(&strmh->cb_cond, NULL);


### PR DESCRIPTION
Suggested changes allows to run `libuvc` on embedded targets with limited amount of RAM, such as microcontollers.

- `LIBUVC_NUM_TRANSFER_BUFS` can be overwritten from cmake file.
- Size of frame buffers is deduced from descriptors (`dwMaxVideoFrameSize`)
