### PR TITLE
memory usage optimization bugbix

### DIFF
--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -227,6 +227,7 @@ typedef struct uvc_device_info {
 #define LIBUVC_NUM_TRANSFER_BUFS 100
 #endif
 
+#define LIBUVC_XFER_META_BUF_SIZE ( 4 * 1024 )
 
 struct uvc_stream_handle {
   struct uvc_device_handle *devh;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1036,8 +1036,8 @@ uvc_error_t uvc_stream_open_ctrl(uvc_device_handle_t *devh, uvc_stream_handle_t 
   strmh->outbuf = malloc( ctrl->dwMaxVideoFrameSize );
   strmh->holdbuf = malloc( ctrl->dwMaxVideoFrameSize );
 
-  strmh->meta_outbuf = malloc( ctrl->dwMaxVideoFrameSize );
-  strmh->meta_holdbuf = malloc( ctrl->dwMaxVideoFrameSize );
+  strmh->meta_outbuf = malloc( LIBUVC_XFER_META_BUF_SIZE );
+  strmh->meta_holdbuf = malloc( LIBUVC_XFER_META_BUF_SIZE );
    
   pthread_mutex_init(&strmh->cb_mutex, NULL);
   pthread_cond_init(&strmh->cb_cond, NULL);


### PR DESCRIPTION
Unfortunately, I introduced an unwanted change in my previous PR #177.
`meta_outbuf ` and `meta_holdbuf` buffers are now unnecessarily large.
Therefore, I am changing its size back to 4K as it was before.
Sorry, my bad. 