### PR TITLE
add basic UVC 1.50 support

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -1091,6 +1091,8 @@ uvc_error_t uvc_parse_vc_header(uvc_device_t *dev,
     break;
   case 0x0110:
     break;
+  case 0x0150:
+    break;
   default:
     UVC_EXIT(UVC_ERROR_NOT_SUPPORTED);
     return UVC_ERROR_NOT_SUPPORTED;

--- a/src/stream.c
+++ b/src/stream.c
@@ -191,16 +191,18 @@ uvc_error_t uvc_query_stream_ctrl(
     uvc_stream_ctrl_t *ctrl,
     uint8_t probe,
     enum uvc_req_code req) {
-  uint8_t buf[34];
+  uint8_t buf[48];
   size_t len;
   uvc_error_t err;
 
   memset(buf, 0, sizeof(buf));
 
-  if (devh->info->ctrl_if.bcdUVC >= 0x0110)
+  if (devh->info->ctrl_if.bcdUVC < 0x0110)
+    len = 26;
+  else if (devh->info->ctrl_if.bcdUVC < 0x0150)
     len = 34;
   else
-    len = 26;
+    len = 48;
 
   /* prepare for a SET transfer */
   if (req == UVC_SET_CUR) {
@@ -216,7 +218,7 @@ uvc_error_t uvc_query_stream_ctrl(
     INT_TO_DW(ctrl->dwMaxVideoFrameSize, buf + 18);
     INT_TO_DW(ctrl->dwMaxPayloadTransferSize, buf + 22);
 
-    if (len == 34) {
+    if (len >= 34) {
       INT_TO_DW ( ctrl->dwClockFrequency, buf + 26 );
       buf[30] = ctrl->bmFramingInfo;
       buf[31] = ctrl->bPreferredVersion;
@@ -254,7 +256,7 @@ uvc_error_t uvc_query_stream_ctrl(
     ctrl->dwMaxVideoFrameSize = DW_TO_INT(buf + 18);
     ctrl->dwMaxPayloadTransferSize = DW_TO_INT(buf + 22);
 
-    if (len == 34) {
+    if (len >= 34) {
       ctrl->dwClockFrequency = DW_TO_INT ( buf + 26 );
       ctrl->bmFramingInfo = buf[30];
       ctrl->bPreferredVersion = buf[31];


### PR DESCRIPTION
The size of stream control probe/commit messages changed with UVC 1.50.
In theory, the spec allows the webcam to remain functional even if the
host uses the incorrect size.
Yet, some webcams (such as as the one found in a Thinkpad T490s,
pid:vid=04f2:b67c) just respond with a stall error.