### PR TITLE
add pts field for uvc_frame_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Build directory (recommended location)
 build/
+include/libuvc/libuvc_config.h

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -483,6 +483,8 @@ typedef struct uvc_frame {
   void *metadata;
   /** Size of metadata buffer */
   size_t metadata_bytes;
+  /** Presentation Time Stamp, add by weller */
+  uint32_t pts;
 } uvc_frame_t;
 
 /** A callback function to handle incoming assembled UVC frames

--- a/src/stream.c
+++ b/src/stream.c
@@ -1355,6 +1355,7 @@ void _uvc_populate_frame(uvc_stream_handle_t *strmh) {
     break;
   }
 
+  frame->pts = strmh->hold_pts; // add pts to frame by weller
   frame->sequence = strmh->hold_seq;
   frame->capture_time_finished = strmh->capture_time_finished;
 


### PR DESCRIPTION
1、Sometimes you need to get PTS in the callback, so add the PTS variable here.

2、include/libuvc/libuvc_config.h
This file is generated dynamically, and it exists every time to exec "git status", so it needs to be ignored