### PR TITLE
Reduce default number of transfer bufs for MacOS builds

### DIFF
--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -224,7 +224,11 @@ typedef struct uvc_device_info {
   this macro.
  */
 #ifndef LIBUVC_NUM_TRANSFER_BUFS
+#if defined(__APPLE__) && defined(__MACH__)
+#define LIBUVC_NUM_TRANSFER_BUFS 20
+#else
 #define LIBUVC_NUM_TRANSFER_BUFS 100
+#endif
 #endif
 
 #define LIBUVC_XFER_META_BUF_SIZE ( 4 * 1024 )


### PR DESCRIPTION
On isochronous transfers, libusb_submit_transfer will choke when
more than 27 buffers are queued at a time. It has done for every
major MacOS release for years, and continues to be the case.

This change reducees the default number of transfer buffers for Mac
builds to a safe number with some margin.