### PR TITLE
Avoid freeing transfers prematurely (possibly fixes issue #152 and #53).

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -1491,15 +1491,12 @@ uvc_error_t uvc_stream_stop(uvc_stream_handle_t *strmh) {
 
   pthread_mutex_lock(&strmh->cb_mutex);
 
+  /* Attempt to cancel any running transfers, we can't free them just yet because they aren't
+   *   necessarily completed but they will be free'd in _uvc_stream_callback().
+   */
   for(i=0; i < LIBUVC_NUM_TRANSFER_BUFS; i++) {
-    if(strmh->transfers[i] != NULL) {
-      int res = libusb_cancel_transfer(strmh->transfers[i]);
-      if(res < 0 && res != LIBUSB_ERROR_NOT_FOUND ) {
-        free(strmh->transfers[i]->buffer);
-        libusb_free_transfer(strmh->transfers[i]);
-        strmh->transfers[i] = NULL;
-      }
-    }
+    if(strmh->transfers[i] != NULL)
+      libusb_cancel_transfer(strmh->transfers[i]);
   }
 
   /* Wait for transfers to complete/cancel */


### PR DESCRIPTION
I had an issue due to uvc_stream_stop() freeing transfers when libusb_cancel_transfer() returned errors, because libusb apparently does not consider these transfers "completed" until it has handled them via libusb_handle_events(). What happens is that libusb_free_transfer() will destroy a mutex in the transfer struct, and later libusb will attempt to lock that mutex. At least on android this outright crashes the process. It can be reproduced by (physically) disconnecting a device many times and if you get lucky there will be an attempt to lock that mutex.

Not freeing the transfers right there and then if cancelling them fails should not be a problem because later the event handling thread is resumed to wait for transfer completions, where they get free'd when they complete/fail or finish cancelling. I've empirically verified this by temporarily adding some logging stuff (not committed to git).

This also matches the libusb documentation which states "It is not legal to free an active transfer (one which has been submitted and has not yet completed).". The same goes for when cancelling does succeed as the documentation says "This function returns immediately, but this does not indicate cancellation is complete." about libusb_cancel_transfer(), but that's probably of limited relevance since the free did not happen when cancel did succeed.

This possibly fixes issue #152 and #53 (i suspect these to be closely related if not the same problem).