### PR TITLE
discard corrupt frame in previously unhandled error case

### DIFF
--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -266,6 +266,8 @@ struct uvc_stream_handle {
   /* raw metadata buffer if available */
   uint8_t *meta_outbuf, *meta_holdbuf;
   size_t meta_got_bytes, meta_hold_bytes;
+
+  uint8_t frame_had_errors;
 };
 
 /** Handle on an open UVC device

--- a/src/stream.c
+++ b/src/stream.c
@@ -671,7 +671,9 @@ void _uvc_swap_buffers(uvc_stream_handle_t *strmh) {
   strmh->meta_outbuf = tmp_buf;
   strmh->meta_hold_bytes = strmh->meta_got_bytes;
 
-  pthread_cond_broadcast(&strmh->cb_cond);
+  if (!strmh->frame_had_errors)
+    pthread_cond_broadcast(&strmh->cb_cond);
+  strmh->frame_had_errors=0;
   pthread_mutex_unlock(&strmh->cb_mutex);
 
   strmh->seq++;
@@ -819,6 +821,7 @@ void LIBUSB_CALL _uvc_stream_callback(struct libusb_transfer *transfer) {
 
         if (pkt->status != 0) {
           UVC_DEBUG("bad packet (isochronous transfer); status: %d", pkt->status);
+          strmh->frame_had_errors=1;
           continue;
         }
 


### PR DESCRIPTION
`_uvc_stream_callback()` in stream.c has this strange-looking code that detects an error but does not handle it,
other than by discarding the data:
```
[stream.c:839/_uvc_stream_callback] not retrying transfer, status = 3
```
```
        if (pkt->status != 0) { 
          UVC_DEBUG("bad packet (isochronous transfer); status: %d", pkt->status);
          continue;
        }    
```

i see this case regularly with my camera, and the resulting frames are corrupt.

i adjusted the code to discard those corrupt frames.

(i also tries setting `resubmit = 1` for this case - it reduced the frequency of corruption but did not fix it.)