### PR TITLE
Fix missing link library when option UVC_DEBUGING is on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,15 @@ foreach(target_name IN LISTS UVC_TARGETS)
       PRIVATE
         UVC_DEBUGGING
     )
+    find_library(
+            log-lib
+            log
+    )
+    target_link_libraries(
+            ${target_name}
+            PRIVATE
+            ${log-lib}
+    )
   endif()
 endforeach()
 


### PR DESCRIPTION
when the option UVC_DEBUGING is set to be on, there's a link error of missing android log libraries.
this pr tries to fix this issue.