### PR TITLE
replaced fprintf statement to UVC_DEBUG

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -382,8 +382,7 @@ static uvc_error_t uvc_open_internal(
     UVC_DEBUG("libusb_submit_transfer() = %d", ret);
 
     if (ret) {
-      fprintf(stderr,
-              "uvc: device has a status interrupt endpoint, but unable to read from it\n");
+      UVC_DEBUG("uvc: device has a status interrupt endpoint, but unable to read from it\n");
       goto fail;
     }
   }


### PR DESCRIPTION
removed a bad fprintf that outputted to a consuming libraries standard console output