### PR TITLE
Functionality to open UVC device without detachment of kernel drivers

### DIFF
--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -529,6 +529,11 @@ typedef struct uvc_still_ctrl {
   uint8_t bInterfaceNumber;
 } uvc_still_ctrl_t;
 
+enum uvc_kernel_driver_mode {
+  UVC_KERNEL_DRIVER_MODE_DETACH_OFF = 0,
+  UVC_KERNEL_DRIVER_MODE_DETACH_ON = 1,
+};
+
 uvc_error_t uvc_init(uvc_context_t **ctx, struct libusb_context *usb_ctx);
 void uvc_exit(uvc_context_t *ctx);
 
@@ -567,6 +572,11 @@ uvc_error_t uvc_open(
     uvc_device_t *dev,
     uvc_device_handle_t **devh);
 void uvc_close(uvc_device_handle_t *devh);
+
+uvc_error_t uvc_open_with_driver_mode(
+    uvc_device_t *dev,
+    uvc_device_handle_t **devh,
+    enum uvc_kernel_driver_mode kernel_driver_mode);
 
 uvc_device_t *uvc_get_device(uvc_device_handle_t *devh);
 struct libusb_device_handle *uvc_get_libusb_handle(uvc_device_handle_t *devh);

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -566,6 +566,12 @@ uvc_error_t uvc_wrap(
     int sys_dev,
     uvc_context_t *context,
     uvc_device_handle_t **devh);
+
+uvc_error_t uvc_wrap_with_driver_mode(
+    int sys_dev,
+    uvc_context_t *context,
+    uvc_device_handle_t **devh,
+    enum uvc_kernel_driver_mode kernel_driver_mode);
 #endif
 
 uvc_error_t uvc_open(

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -291,8 +291,8 @@ struct uvc_device_handle {
   /** Whether the camera is an iSight that sends one header per frame */
   uint8_t is_isight;
   uint32_t claimed;
-  uint8_t detached;
-  uint32_t should_detach;
+  uint32_t detached;
+  uint8_t should_detach;
 };
 
 /** Context within which we communicate with devices */

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -292,6 +292,7 @@ struct uvc_device_handle {
   uint8_t is_isight;
   uint32_t claimed;
   uint8_t detached;
+  uint8_t should_detach;
 };
 
 /** Context within which we communicate with devices */
@@ -313,7 +314,7 @@ uvc_error_t uvc_query_stream_ctrl(
     enum uvc_req_code req);
 
 void uvc_start_handler_thread(uvc_context_t *ctx);
-uvc_error_t uvc_claim_if(uvc_device_handle_t *devh, int idx, enum uvc_kernel_driver_mode kernel_driver_mode);
+uvc_error_t uvc_claim_if(uvc_device_handle_t *devh, int idx);
 uvc_error_t uvc_release_if(uvc_device_handle_t *devh, int idx);
 
 #endif // !def(LIBUVC_INTERNAL_H)

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -291,6 +291,7 @@ struct uvc_device_handle {
   /** Whether the camera is an iSight that sends one header per frame */
   uint8_t is_isight;
   uint32_t claimed;
+  uint8_t detached;
 };
 
 /** Context within which we communicate with devices */
@@ -312,7 +313,7 @@ uvc_error_t uvc_query_stream_ctrl(
     enum uvc_req_code req);
 
 void uvc_start_handler_thread(uvc_context_t *ctx);
-uvc_error_t uvc_claim_if(uvc_device_handle_t *devh, int idx);
+uvc_error_t uvc_claim_if(uvc_device_handle_t *devh, int idx, enum uvc_kernel_driver_mode kernel_driver_mode);
 uvc_error_t uvc_release_if(uvc_device_handle_t *devh, int idx);
 
 #endif // !def(LIBUVC_INTERNAL_H)

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -292,7 +292,7 @@ struct uvc_device_handle {
   uint8_t is_isight;
   uint32_t claimed;
   uint8_t detached;
-  uint8_t should_detach;
+  uint32_t should_detach;
 };
 
 /** Context within which we communicate with devices */

--- a/src/stream.c
+++ b/src/stream.c
@@ -493,7 +493,7 @@ uvc_error_t uvc_get_stream_ctrl_format_size(
 
         ctrl->bInterfaceNumber = stream_if->bInterfaceNumber;
         UVC_DEBUG("claiming streaming interface %d", stream_if->bInterfaceNumber );
-        uvc_claim_if(devh, ctrl->bInterfaceNumber);
+        uvc_claim_if(devh, ctrl->bInterfaceNumber, (devh->detached ? UVC_KERNEL_DRIVER_MODE_DETACH_ON : UVC_KERNEL_DRIVER_MODE_DETACH_OFF));
         /* get the max values */
         uvc_query_stream_ctrl( devh, ctrl, 1, UVC_GET_MAX);
 
@@ -1030,7 +1030,7 @@ uvc_error_t uvc_stream_open_ctrl(uvc_device_handle_t *devh, uvc_stream_handle_t 
   strmh->stream_if = stream_if;
   strmh->frame.library_owns_data = 1;
 
-  ret = uvc_claim_if(strmh->devh, strmh->stream_if->bInterfaceNumber);
+  ret = uvc_claim_if(strmh->devh, strmh->stream_if->bInterfaceNumber, (devh->detached ? UVC_KERNEL_DRIVER_MODE_DETACH_ON : UVC_KERNEL_DRIVER_MODE_DETACH_OFF));
   if (ret != UVC_SUCCESS)
     goto fail;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -493,7 +493,7 @@ uvc_error_t uvc_get_stream_ctrl_format_size(
 
         ctrl->bInterfaceNumber = stream_if->bInterfaceNumber;
         UVC_DEBUG("claiming streaming interface %d", stream_if->bInterfaceNumber );
-        uvc_claim_if(devh, ctrl->bInterfaceNumber, (devh->detached ? UVC_KERNEL_DRIVER_MODE_DETACH_ON : UVC_KERNEL_DRIVER_MODE_DETACH_OFF));
+        uvc_claim_if(devh, ctrl->bInterfaceNumber);
         /* get the max values */
         uvc_query_stream_ctrl( devh, ctrl, 1, UVC_GET_MAX);
 
@@ -1030,7 +1030,7 @@ uvc_error_t uvc_stream_open_ctrl(uvc_device_handle_t *devh, uvc_stream_handle_t 
   strmh->stream_if = stream_if;
   strmh->frame.library_owns_data = 1;
 
-  ret = uvc_claim_if(strmh->devh, strmh->stream_if->bInterfaceNumber, (devh->detached ? UVC_KERNEL_DRIVER_MODE_DETACH_ON : UVC_KERNEL_DRIVER_MODE_DETACH_OFF));
+  ret = uvc_claim_if(strmh->devh, strmh->stream_if->bInterfaceNumber);
   if (ret != UVC_SUCCESS)
     goto fail;
 


### PR DESCRIPTION
In macOS detachment of kernel drivers can lead to detachment all interfaces of a device.
The API extended for possibility to open an UVC device without detachment of kernel drivers.