### PR TITLE
fix(stream): Accept smaller Max payloads than required

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -597,7 +597,7 @@ static int _uvc_stream_params_negotiated(
   uvc_stream_ctrl_t *actual) {
     return required->bFormatIndex == actual->bFormatIndex &&
     required->bFrameIndex == actual->bFrameIndex &&
-    required->dwMaxPayloadTransferSize == actual->dwMaxPayloadTransferSize;
+    required->dwMaxPayloadTransferSize >= actual->dwMaxPayloadTransferSize;
 }
 
 /** @internal


### PR DESCRIPTION
In #178 negotiatation check was added that is too strict. Some HighSpeed USB cameras will return smaller Max payload than what the libuvc requests

@waddlesplash 