### PR TITLE
make number of buffers configurable

### DIFF
--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -632,6 +632,8 @@ uvc_error_t uvc_start_iso_streaming(
 
 void uvc_stop_streaming(uvc_device_handle_t *devh);
 
+void uvc_stream_set_default_number_of_transport_buffers(size_t s);
+
 uvc_error_t uvc_stream_open_ctrl(uvc_device_handle_t *devh, uvc_stream_handle_t **strmh, uvc_stream_ctrl_t *ctrl);
 uvc_error_t uvc_stream_ctrl(uvc_stream_handle_t *strmh, uvc_stream_ctrl_t *ctrl);
 uvc_error_t uvc_stream_start(uvc_stream_handle_t *strmh,
@@ -809,4 +811,3 @@ uvc_error_t uvc_mjpeg2gray(uvc_frame_t *in, uvc_frame_t *out);
 #endif
 
 #endif // !def(LIBUVC_H)
-

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -257,8 +257,9 @@ struct uvc_stream_handle {
   uint32_t last_polled_seq;
   uvc_frame_callback_t *user_cb;
   void *user_ptr;
-  struct libusb_transfer *transfers[LIBUVC_NUM_TRANSFER_BUFS];
-  uint8_t *transfer_bufs[LIBUVC_NUM_TRANSFER_BUFS];
+  size_t number_of_transport_buffers;
+  struct libusb_transfer **transfers;
+  uint8_t **transfer_bufs;
   struct uvc_frame frame;
   enum uvc_frame_format frame_format;
   struct timespec capture_time_finished;
@@ -317,4 +318,3 @@ uvc_error_t uvc_release_if(uvc_device_handle_t *devh, int idx);
 
 #endif // !def(LIBUVC_INTERNAL_H)
 /** @endcond */
-

--- a/src/device.c
+++ b/src/device.c
@@ -1138,6 +1138,7 @@ uvc_error_t uvc_parse_vc_header(uvc_device_t *dev,
     info->ctrl_if.dwClockFrequency = DW_TO_INT(block + 7);
     break;
   case 0x0110:
+  case 0x0150: // don't fail on UVC 1.5 devices
     break;
   default:
     UVC_EXIT(UVC_ERROR_NOT_SUPPORTED);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1316,12 +1316,12 @@ uvc_error_t uvc_stream_start(
     } while (ret != UVC_SUCCESS && n_try < n_retry);
 
     if (ret != UVC_SUCCESS) {
-      UVC_DEBUG("libusb_submit_transfer failed: %d",ret);
+      UVC_DEBUG("libusb_submit_transfer failed: %s(%d)", libusb_strerror(ret), ret);
       break;
     }
   }
 
-  if ( ret != UVC_SUCCESS && transfer_id >= 0 ) {
+  if ( ret != UVC_SUCCESS && transfer_id > 0 ) {
     UVC_DEBUG("Will try to work with %d transfers instead of %zd", transfer_id, strmh->number_of_transport_buffers);
     size_t new_number_of_transport_buffers = transfer_id;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -1063,7 +1063,7 @@ uvc_error_t uvc_stream_open_ctrl(uvc_device_handle_t *devh, uvc_stream_handle_t 
     ret = uvc_claim_if(strmh->devh, strmh->stream_if->bInterfaceNumber);
   }
   if (ret != UVC_SUCCESS) {
-    UVC_DEBUG("Failed to claim stream interface: %d %d", strmh->stream_if->bInterfaceNumber);
+    UVC_DEBUG("Failed to claim stream interface: %d %d", ret, strmh->stream_if->bInterfaceNumber);
     goto fail;
   }
 
@@ -1322,7 +1322,7 @@ uvc_error_t uvc_stream_start(
   }
 
   if ( ret != UVC_SUCCESS && transfer_id >= 0 ) {
-    UVC_DEBUG("Will try to work with %zd transfers instead of %zd", transfer_id, strmh->number_of_transport_buffers);
+    UVC_DEBUG("Will try to work with %d transfers instead of %zd", transfer_id, strmh->number_of_transport_buffers);
     size_t new_number_of_transport_buffers = transfer_id;
 
     for ( ; transfer_id < strmh->number_of_transport_buffers; transfer_id++) {


### PR DESCRIPTION
Right now, current libuvc create 100 buffers, plus as many transfers. Unsurprisingly, this tends to fail quite often on non-root android. This PR makes the default number of transfers and buffers configurable by the user.

This is a (very late) follow up on PR 103 (https://github.com/libuvc/libuvc/pull/103)