### PR TITLE
Remove Check for dwMaxPayloadTransferSize _uvc_stream_params_negotiated

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -596,8 +596,7 @@ static int _uvc_stream_params_negotiated(
   uvc_stream_ctrl_t *required,
   uvc_stream_ctrl_t *actual) {
     return required->bFormatIndex == actual->bFormatIndex &&
-    required->bFrameIndex == actual->bFrameIndex &&
-    required->dwMaxPayloadTransferSize >= actual->dwMaxPayloadTransferSize;
+    required->bFrameIndex == actual->bFrameIndex;
 }
 
 /** @internal


### PR DESCRIPTION

I have four webcams (Logitech C270, C992, MX Brio, and Razer KIYO PRO ULTRA 4), and I've encountered an issue where the required dwMaxPayloadTransferSize and actual dwMaxPayloadTransferSize values differ for the MX Brio and KIYO. I believe this issue is specific to high-performance webcams that use USB 3.0 or higher. Removing the check for this discrepancy should help resolve the problem.