### PR TITLE
Fix the memory leak of uvc_stream_close

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -1548,6 +1548,9 @@ void uvc_stream_close(uvc_stream_handle_t *strmh) {
   if (strmh->frame.data)
     free(strmh->frame.data);
 
+  if (strmh->frame.metadata)
+    free(strmh->frame.metadata);
+
   free(strmh->outbuf);
   free(strmh->holdbuf);
 


### PR DESCRIPTION
If the device contains metadata, calling uvc_stream_close does not release the metadata memory.