### PR TITLE
ctrl-gen: fix script to run on Python 3 and PyYAML 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,42 @@ jobs:
       - name: Check example was built
         run: test -x build/example
 
+  # src/ctrl-gen.c and the control accessors in libuvc.h are generated from
+  # standard-units.yaml by src/ctrl-gen.py. Regenerate them here so the
+  # committed copies cannot drift from the generator or the YAML.
+  check-generated:
+    runs-on: ubuntu-latest
+
+    name: check generated files
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Check src/ctrl-gen.c is up to date
+        run: |
+          python3 src/ctrl-gen.py -i standard-units.yaml def > ctrl-gen.c.new
+          diff -u src/ctrl-gen.c ctrl-gen.c.new
+
+      - name: Check the generated block of libuvc.h is up to date
+        run: |
+          # Extract the block between the AUTO-GENERATED markers, excluding
+          # the marker lines themselves. `decl` ends with a trailing blank
+          # line that the header does not carry, so strip trailing blanks
+          # from both sides before comparing.
+          sed -n '/AUTO-GENERATED control accessors! Update/,/end AUTO-GENERATED/p' \
+            include/libuvc/libuvc.h | sed '1d;$d' > libuvc.h.block
+          python3 src/ctrl-gen.py -i standard-units.yaml decl > libuvc.h.new
+          diff -u <(sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' libuvc.h.block) \
+                  <(sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' libuvc.h.new)
+
+      - name: Check standard-units.yaml round-trips
+        run: |
+          python3 src/ctrl-gen.py -i standard-units.yaml yaml > standard-units.yaml.new
+          diff -u standard-units.yaml standard-units.yaml.new
+
   # The test program needs OpenCV, so it is built separately to keep the
   # dependency out of the main matrix.
   build-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,13 +147,28 @@ jobs:
 
       - name: Check the generated block of libuvc.h is up to date
         run: |
-          # Extract the block between the AUTO-GENERATED markers, excluding
-          # the marker lines themselves. `decl` ends with a trailing blank
-          # line that the header does not carry, so strip trailing blanks
-          # from both sides before comparing.
-          sed -n '/AUTO-GENERATED control accessors! Update/,/end AUTO-GENERATED/p' \
+          # Unlike ctrl-gen.c, libuvc.h is only partly generated: `decl`
+          # emits just the accessor prototypes, and the rest of the header
+          # is hand written. So compare the region between the markers.
+          # Fail loudly if a marker is missing, otherwise a reworded marker
+          # would silently shrink the extracted block and the diff would
+          # pass while checking nothing.
+          grep -c '^/\* AUTO-GENERATED control accessors' include/libuvc/libuvc.h \
+            | grep -qx 1 || { echo "start marker missing/duplicated" >&2; exit 1; }
+          grep -c '^/\* end AUTO-GENERATED control accessors \*/$' include/libuvc/libuvc.h \
+            | grep -qx 1 || { echo "end marker missing/duplicated" >&2; exit 1; }
+
+          sed -n '/^\/\* AUTO-GENERATED control accessors/,/^\/\* end AUTO-GENERATED control accessors \*\/$/p' \
             include/libuvc/libuvc.h | sed '1d;$d' > libuvc.h.block
           python3 src/ctrl-gen.py -i standard-units.yaml decl > libuvc.h.new
+
+          # Sanity-check that extraction actually found the accessors, so a
+          # future header reshuffle cannot reduce this to an empty diff.
+          test "$(wc -l < libuvc.h.block)" -gt 100 || {
+            echo "extracted block implausibly short" >&2; exit 1; }
+
+          # `decl` ends with a trailing blank line the header does not
+          # carry, so strip trailing blanks from both sides.
           diff -u <(sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' libuvc.h.block) \
                   <(sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' libuvc.h.new)
 

--- a/src/ctrl-gen.py
+++ b/src/ctrl-gen.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 from collections import OrderedDict
 import getopt
 import sys
@@ -24,7 +23,7 @@ yaml.add_representer(OrderedDict, ordered_dict_presenter)
 def dict_constructor(loader, node):
     return OrderedDict(loader.construct_pairs(node))
 _mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
-yaml.add_constructor(_mapping_tag, dict_constructor)
+yaml.add_constructor(_mapping_tag, dict_constructor, Loader=yaml.SafeLoader)
 
 class IntField(object):
     def __init__(self, name, position, length, signed):
@@ -65,10 +64,6 @@ class IntField(object):
         if self.signed:
             rep.append(('signed', True))
         return rep
-
-    @staticmethod
-    def load(spec):
-        return IntField(spec['name'], spec['position'], spec['length'], spec['signed'] if signed in spec else False)
 
 def load_field(name, spec):
     if spec['type'] == 'int':
@@ -241,6 +236,10 @@ def export_unit(unit):
     unit_out['controls'] = OrderedDict([fmt_ctrl(ctrl_name, ctrl_details) for ctrl_name, ctrl_details in unit['controls'].items()])
     return unit_out
 
+def usage():
+    print("Usage: {0} [-i|--input FILE]... (def|decl|yaml)".format(sys.argv[0]),
+          file=sys.stderr)
+
 if __name__ == '__main__':
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hi:", ["help", "input="])
@@ -273,8 +272,8 @@ if __name__ == '__main__':
     def iterunits():
         for input_file in inputs:
             with open(input_file, "r") as fp:
-                units = yaml.load(fp)['units']
-                for unit_name, unit_details in units.iteritems():
+                units = yaml.load(fp, Loader=yaml.SafeLoader)['units']
+                for unit_name, unit_details in units.items():
                     yield unit_name, unit_details
 
     if mode == 'def':
@@ -297,6 +296,6 @@ static const int REQ_TYPE_GET = 0xa1;
         sys.exit(0)
 
     for unit_name, unit_details in iterunits():
-        for control_name, control_details in unit_details['controls'].iteritems():
+        for control_name, control_details in unit_details['controls'].items():
             code = fun(unit_name, unit_details, control_name, control_details)
             print(code)


### PR DESCRIPTION
(not a Python expert, but this looks sensible and regenerates the file correctly)

The generator has been unrunnable for some time. Fix the Python 2 leftovers and the PyYAML API changes, plus two latent NameErrors:

- yaml.load() requires an explicit Loader since PyYAML 6.
- yaml.add_constructor() must register the OrderedDict mapping constructor on the same loader class that load() uses, otherwise the override silently does not apply and key order is lost.
- Replace the two remaining dict.iteritems() calls with items().
- Define usage(). It was called on the --help and bad-option paths but never defined, so both raised NameError.
- Drop the unused IntField.load(), which referenced a bare undefined name `signed` instead of the string 'signed' and so could only ever raise NameError.
- Update the shebang to python3 and drop the now-redundant __future__ import.

No output change: all three modes (def, decl, yaml) reproduce the committed src/ctrl-gen.c, the generated block of libuvc.h, and standard-units.yaml byte for byte.