### PR TITLE
new cmake option DISABLE_JPEG, fix test to use C++ (revive and update #287)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 option(BUILD_EXAMPLE "Build example program" ON)
 option(BUILD_TEST "Build test program" OFF)
 option(ENABLE_UVC_DEBUGGING "Enable UVC debugging" OFF)
+option(DISABLE_JPEG "Disable JPEG support" OFF)
 
 set(libuvc_DESCRIPTION "A cross-platform library for USB video devices")
 set(libuvc_URL "https://github.com/libuvc/libuvc")
@@ -41,14 +42,18 @@ set(SOURCES
 
 find_package(LibUSB)
 
-# JpegPkg name to differ from shipped with CMake
-find_package(JpegPkg QUIET)
-if(JPEG_FOUND)
-  message(STATUS "Building libuvc with JPEG support.")
-  set(LIBUVC_HAS_JPEG TRUE)
-  list(APPEND SOURCES src/frame-mjpeg.c)
+if(DISABLE_JPEG)
+  message(WARNING "libuvc will not support JPEG decoding.")
 else()
-  message(WARNING "JPEG not found. libuvc will not support JPEG decoding.")
+  # JpegPkg name to differ from shipped with CMake
+  find_package(JpegPkg QUIET)
+  if(JPEG_FOUND)
+    message(STATUS "Building libuvc with JPEG support.")
+    set(LIBUVC_HAS_JPEG TRUE)
+    list(APPEND SOURCES src/frame-mjpeg.c)
+  else()
+    message(WARNING "JPEG not found. libuvc will not support JPEG decoding.")
+  endif()
 endif()
 
 if(UNIX AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(SOURCES
 find_package(LibUSB)
 
 if(DISABLE_JPEG)
-  message(WARNING "libuvc will not support JPEG decoding.")
+  message(STATUS "libuvc will not support JPEG decoding.")
 else()
   # JpegPkg name to differ from shipped with CMake
   find_package(JpegPkg QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(libuvc
   VERSION 0.0.7
-  LANGUAGES C
+  LANGUAGES C CXX
 )
 
 # Additional search scripts path for libusb-1.0, libjpeg, OpenCV
@@ -167,7 +167,22 @@ if(BUILD_TEST)
       opencv_highgui
   )
 
-  add_executable(uvc_test src/test.c)
+  if(OpenCVPkg_FOUND)
+    # Our example written in C language but found OpenCV modules does
+    # not always contains C include files. So we need to additional check.
+    # highgui_c.h is currently broken.
+    find_file(highgui_path
+      HINTS /usr/include/opencv4 /usr/local/include/opencv4
+      NAMES opencv2/highgui/highgui_c.h
+    )
+    if(highgui_path)
+      message(STATUS "C include file for HighGUI OpenCV module found")
+    else()
+      message(FATAL_ERROR "C include file for HighGUI OpenCV module not found. In Ubuntu it located within libopencv-dev or libhighgui-dev")
+    endif()
+  endif()
+
+  add_executable(uvc_test src/test.cxx)
   target_link_libraries(uvc_test
     PRIVATE
       LibUVC::UVC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(libuvc
   VERSION 0.0.7
-  LANGUAGES C CXX
+  LANGUAGES C
 )
 
 # Additional search scripts path for libusb-1.0, libjpeg, OpenCV
@@ -159,6 +159,10 @@ if(BUILD_EXAMPLE)
 endif()
 
 if(BUILD_TEST)
+  # Only the test program is C++; the library itself is C, so do not
+  # require a C++ compiler unless the test is actually built.
+  enable_language(CXX)
+
   # OpenCV defines targets with transitive dependencies not with namespaces but using opencv_ prefix. 
   # This targets provide necessary include directories and linked flags.
   find_package(OpenCVPkg REQUIRED
@@ -172,7 +176,10 @@ if(BUILD_TEST)
     # not always contains C include files. So we need to additional check.
     # highgui_c.h is currently broken.
     find_file(highgui_path
-      HINTS /usr/include/opencv4 /usr/local/include/opencv4
+      HINTS
+        ${OpenCV_INCLUDE_DIRS}
+        ${OpenCV_opencv_highgui_INCLUDE_DIR}
+      PATH_SUFFIXES opencv4
       NAMES opencv2/highgui/highgui_c.h
     )
     if(highgui_path)

--- a/src/test.cxx
+++ b/src/test.cxx
@@ -32,16 +32,19 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 #include <stdio.h>
+#include <unistd.h>
 #include <opencv2/highgui/highgui_c.h>
 
 #include "libuvc/libuvc.h"
+
+using namespace cv;
 
 void cb(uvc_frame_t *frame, void *ptr) {
   uvc_frame_t *bgr;
   uvc_error_t ret;
   IplImage* cvImg;
 
-  printf("callback! length = %u, ptr = %d\n", frame->data_bytes, (int) ptr);
+  printf("callback! length = %zu, ptr = %p\n", frame->data_bytes, ptr);
 
   bgr = uvc_allocate_frame(frame->width * frame->height * 3);
   if (!bgr) {
@@ -115,7 +118,7 @@ int main(int argc, char **argv) {
       if (res < 0) {
         uvc_perror(res, "get_mode");
       } else {
-        res = uvc_start_streaming(devh, &ctrl, cb, 12345, 0);
+        res = uvc_start_streaming(devh, &ctrl, cb, (void*)12345, 0);
 
         if (res < 0) {
           uvc_perror(res, "start_streaming");


### PR DESCRIPTION
Picks only the relevant commits from #287 (from @rurban).

Also incorporates the changes requested at the time by @Youw.

Note that OpenCV 5 completely removes C API support, so this is a stop gap (I have an additional commit ready).