### PR TITLE
fix out-of-bounds access in uvc_yuyv2bgr() (revive and fixup #211), and add unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,3 +237,46 @@ jobs:
         run: |
           test -x build/example
           test -x build/uvc_test
+
+  # The frame converter unit tests. Run under AddressSanitizer and
+  # UndefinedBehaviorSanitizer: several of the cases check that a converter
+  # stays inside its input buffer, and without a sanitizer an overread just
+  # returns stale heap bytes and the test passes.
+  #
+  # Both gcc and clang, since the two sanitizer runtimes do not always report
+  # the same thing.
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ gcc, clang ]
+
+    name: ${{ matrix.compiler }}, unit tests
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libusb-1.0-0-dev libjpeg-dev libgtest-dev
+
+      - name: Configure
+        env:
+          CC: ${{ matrix.compiler }}
+          CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
+        run: |
+          cmake -B build \
+            -DBUILD_TESTING=ON \
+            -DENABLE_SANITIZERS=ON \
+            -DBUILD_EXAMPLE=OFF
+
+      - name: Build
+        run: cmake --build build
+
+      # --output-on-failure so a failing case shows its sanitizer report in
+      # the log rather than just a test name.
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 project(libuvc
   VERSION 0.0.7
   LANGUAGES C
@@ -27,6 +27,8 @@ option(ENABLE_UVC_DEBUGGING "Enable UVC debugging" OFF)
 option(DISABLE_JPEG "Disable JPEG support" OFF)
 option(ENABLE_WARNINGS "Build with a common set of compiler warnings enabled" ON)
 option(WARNINGS_AS_ERRORS "Turn compiler warnings into errors (used by CI)" OFF)
+option(BUILD_TESTING "Build the unit tests" OFF)
+option(ENABLE_SANITIZERS "Build with AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 
 # Applied to every target defined below, including the example and test
 # programs. Kept off for MSVC, which does not understand these flags.
@@ -39,6 +41,14 @@ if(WARNINGS_AS_ERRORS)
   else()
     add_compile_options(-Werror)
   endif()
+endif()
+
+# Applied to the whole build, not just the tests: an out-of-bounds read
+# inside the library is only caught if the library itself is instrumented.
+if(ENABLE_SANITIZERS)
+  set(uvc_sanitizer_flags -fsanitize=address,undefined -fno-omit-frame-pointer)
+  add_compile_options(${uvc_sanitizer_flags})
+  add_link_options(${uvc_sanitizer_flags})
 endif()
 
 set(libuvc_DESCRIPTION "A cross-platform library for USB video devices")
@@ -193,6 +203,13 @@ if(BUILD_TEST)
       opencv_core
       opencv_highgui
   )
+endif()
+
+if(BUILD_TESTING)
+  # enable_language(CXX) happens inside test/, so a build with
+  # BUILD_TESTING=OFF never requires a C++ compiler.
+  enable_testing()
+  add_subdirectory(test)
 endif()
 
 

--- a/src/frame.c
+++ b/src/frame.c
@@ -175,6 +175,9 @@ uvc_error_t uvc_yuyv2rgb(uvc_frame_t *in, uvc_frame_t *out) {
   if (in->frame_format != UVC_FRAME_FORMAT_YUYV)
     return UVC_ERROR_INVALID_PARAM;
 
+  if (in->data_bytes < in->width * in->height * 2)
+    return UVC_ERROR_INVALID_PARAM;
+
   if (uvc_ensure_frame_size(out, in->width * in->height * 3) < 0)
     return UVC_ERROR_NO_MEM;
 
@@ -189,9 +192,10 @@ uvc_error_t uvc_yuyv2rgb(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *prgb = out->data;
-  uint8_t *prgb_end = prgb + out->data_bytes;
+  uint8_t *prgb_end = prgb + out->data_bytes - 3 * 8 + 1;
+  uint8_t *pyuv_end = in->data + in->data_bytes - 2 * 8 + 1;
 
-  while (prgb < prgb_end) {
+  while (prgb < prgb_end && pyuv < pyuv_end) {
     IYUYV2RGB_8(pyuv, prgb);
 
     prgb += 3 * 8;
@@ -226,6 +230,9 @@ uvc_error_t uvc_yuyv2bgr(uvc_frame_t *in, uvc_frame_t *out) {
   if (in->frame_format != UVC_FRAME_FORMAT_YUYV)
     return UVC_ERROR_INVALID_PARAM;
 
+  if (in->data_bytes < in->width * in->height * 2)
+    return UVC_ERROR_INVALID_PARAM;
+
   if (uvc_ensure_frame_size(out, in->width * in->height * 3) < 0)
     return UVC_ERROR_NO_MEM;
 
@@ -240,9 +247,10 @@ uvc_error_t uvc_yuyv2bgr(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *pbgr = out->data;
-  uint8_t *pbgr_end = pbgr + out->data_bytes;
+  uint8_t *pyuv_end = in->data + in->data_bytes;
+  uint8_t *pbgr_end = out->data + out->data_bytes;
 
-  while (pbgr < pbgr_end) {
+  while (pyuv < pyuv_end && pbgr < pbgr_end) {
     IYUYV2BGR_8(pyuv, pbgr);
 
     pbgr += 3 * 8;

--- a/src/frame.c
+++ b/src/frame.c
@@ -175,10 +175,10 @@ uvc_error_t uvc_yuyv2rgb(uvc_frame_t *in, uvc_frame_t *out) {
   if (in->frame_format != UVC_FRAME_FORMAT_YUYV)
     return UVC_ERROR_INVALID_PARAM;
 
-  if (in->data_bytes < in->width * in->height * 2)
+  if (in->data_bytes < (size_t)in->width * in->height * 2)
     return UVC_ERROR_INVALID_PARAM;
 
-  if (uvc_ensure_frame_size(out, in->width * in->height * 3) < 0)
+  if (uvc_ensure_frame_size(out, (size_t)in->width * in->height * 3) < 0)
     return UVC_ERROR_NO_MEM;
 
   out->width = in->width;
@@ -192,10 +192,15 @@ uvc_error_t uvc_yuyv2rgb(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *prgb = out->data;
-  uint8_t *prgb_end = prgb + out->data_bytes - 3 * 8 + 1;
-  uint8_t *pyuv_end = in->data + in->data_bytes - 2 * 8 + 1;
 
-  while (prgb < prgb_end && pyuv < pyuv_end) {
+  /* Derive the end from the geometry, which both buffers were checked
+     against above, rather than from out->data_bytes -- a caller supplied
+     buffer may be larger than the frame needs. Converts 8 pixels at a
+     time; a width that is not a multiple of 8 leaves the few trailing
+     pixels unconverted, as before. */
+  uint8_t *prgb_end = prgb + (size_t)in->width * in->height / 8 * (3 * 8);
+
+  while (prgb < prgb_end) {
     IYUYV2RGB_8(pyuv, prgb);
 
     prgb += 3 * 8;
@@ -230,10 +235,10 @@ uvc_error_t uvc_yuyv2bgr(uvc_frame_t *in, uvc_frame_t *out) {
   if (in->frame_format != UVC_FRAME_FORMAT_YUYV)
     return UVC_ERROR_INVALID_PARAM;
 
-  if (in->data_bytes < in->width * in->height * 2)
+  if (in->data_bytes < (size_t)in->width * in->height * 2)
     return UVC_ERROR_INVALID_PARAM;
 
-  if (uvc_ensure_frame_size(out, in->width * in->height * 3) < 0)
+  if (uvc_ensure_frame_size(out, (size_t)in->width * in->height * 3) < 0)
     return UVC_ERROR_NO_MEM;
 
   out->width = in->width;
@@ -247,10 +252,11 @@ uvc_error_t uvc_yuyv2bgr(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *pbgr = out->data;
-  uint8_t *pyuv_end = in->data + in->data_bytes;
-  uint8_t *pbgr_end = out->data + out->data_bytes;
 
-  while (pyuv < pyuv_end && pbgr < pbgr_end) {
+  /* See uvc_yuyv2rgb(): the end comes from the geometry, not data_bytes. */
+  uint8_t *pbgr_end = pbgr + (size_t)in->width * in->height / 8 * (3 * 8);
+
+  while (pbgr < pbgr_end) {
     IYUYV2BGR_8(pyuv, pbgr);
 
     pbgr += 3 * 8;
@@ -274,7 +280,10 @@ uvc_error_t uvc_yuyv2y(uvc_frame_t *in, uvc_frame_t *out) {
   if (in->frame_format != UVC_FRAME_FORMAT_YUYV)
     return UVC_ERROR_INVALID_PARAM;
 
-  if (uvc_ensure_frame_size(out, in->width * in->height) < 0)
+  if (in->data_bytes < (size_t)in->width * in->height * 2)
+    return UVC_ERROR_INVALID_PARAM;
+
+  if (uvc_ensure_frame_size(out, (size_t)in->width * in->height) < 0)
     return UVC_ERROR_NO_MEM;
 
   out->width = in->width;
@@ -288,7 +297,9 @@ uvc_error_t uvc_yuyv2y(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *py = out->data;
-  uint8_t *py_end = py + out->data_bytes;
+
+  /* See uvc_yuyv2rgb(): the end comes from the geometry, not data_bytes. */
+  uint8_t *py_end = py + (size_t)in->width * in->height;
 
   while (py < py_end) {
     IYUYV2Y(pyuv, py);
@@ -314,7 +325,10 @@ uvc_error_t uvc_yuyv2uv(uvc_frame_t *in, uvc_frame_t *out) {
   if (in->frame_format != UVC_FRAME_FORMAT_YUYV)
     return UVC_ERROR_INVALID_PARAM;
 
-  if (uvc_ensure_frame_size(out, in->width * in->height) < 0)
+  if (in->data_bytes < (size_t)in->width * in->height * 2)
+    return UVC_ERROR_INVALID_PARAM;
+
+  if (uvc_ensure_frame_size(out, (size_t)in->width * in->height) < 0)
     return UVC_ERROR_NO_MEM;
 
   out->width = in->width;
@@ -328,7 +342,9 @@ uvc_error_t uvc_yuyv2uv(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *puv = out->data;
-  uint8_t *puv_end = puv + out->data_bytes;
+
+  /* See uvc_yuyv2rgb(): the end comes from the geometry, not data_bytes. */
+  uint8_t *puv_end = puv + (size_t)in->width * in->height;
 
   while (puv < puv_end) {
     IYUYV2UV(pyuv, puv);
@@ -364,7 +380,10 @@ uvc_error_t uvc_uyvy2rgb(uvc_frame_t *in, uvc_frame_t *out) {
   if (in->frame_format != UVC_FRAME_FORMAT_UYVY)
     return UVC_ERROR_INVALID_PARAM;
 
-  if (uvc_ensure_frame_size(out, in->width * in->height * 3) < 0)
+  if (in->data_bytes < (size_t)in->width * in->height * 2)
+    return UVC_ERROR_INVALID_PARAM;
+
+  if (uvc_ensure_frame_size(out, (size_t)in->width * in->height * 3) < 0)
     return UVC_ERROR_NO_MEM;
 
   out->width = in->width;
@@ -378,7 +397,9 @@ uvc_error_t uvc_uyvy2rgb(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *prgb = out->data;
-  uint8_t *prgb_end = prgb + out->data_bytes;
+
+  /* See uvc_yuyv2rgb(): the end comes from the geometry, not data_bytes. */
+  uint8_t *prgb_end = prgb + (size_t)in->width * in->height / 8 * (3 * 8);
 
   while (prgb < prgb_end) {
     IUYVY2RGB_8(pyuv, prgb);
@@ -414,7 +435,10 @@ uvc_error_t uvc_uyvy2bgr(uvc_frame_t *in, uvc_frame_t *out) {
   if (in->frame_format != UVC_FRAME_FORMAT_UYVY)
     return UVC_ERROR_INVALID_PARAM;
 
-  if (uvc_ensure_frame_size(out, in->width * in->height * 3) < 0)
+  if (in->data_bytes < (size_t)in->width * in->height * 2)
+    return UVC_ERROR_INVALID_PARAM;
+
+  if (uvc_ensure_frame_size(out, (size_t)in->width * in->height * 3) < 0)
     return UVC_ERROR_NO_MEM;
 
   out->width = in->width;
@@ -428,7 +452,9 @@ uvc_error_t uvc_uyvy2bgr(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *pbgr = out->data;
-  uint8_t *pbgr_end = pbgr + out->data_bytes;
+
+  /* See uvc_yuyv2rgb(): the end comes from the geometry, not data_bytes. */
+  uint8_t *pbgr_end = pbgr + (size_t)in->width * in->height / 8 * (3 * 8);
 
   while (pbgr < pbgr_end) {
     IUYVY2BGR_8(pyuv, pbgr);

--- a/src/frame.c
+++ b/src/frame.c
@@ -193,6 +193,13 @@ uvc_error_t uvc_yuyv2rgb(uvc_frame_t *in, uvc_frame_t *out) {
   uint8_t *pyuv = in->data;
   uint8_t *prgb = out->data;
 
+  /* The 8-pixel unrolled loop below drops any pixels past the last full
+     group, so flag the geometries where that silently loses a tail. */
+  if ((size_t)in->width * in->height % 8 != 0)
+    UVC_DEBUG("%ux%u is not a multiple of 8 pixels, %zu trailing pixel(s) "
+              "left unconverted", in->width, in->height,
+              (size_t)in->width * in->height % 8);
+
   /* Derive the end from the geometry, which both buffers were checked
      against above, rather than from out->data_bytes -- a caller supplied
      buffer may be larger than the frame needs. Converts 8 pixels at a
@@ -252,6 +259,12 @@ uvc_error_t uvc_yuyv2bgr(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *pbgr = out->data;
+
+  /* See uvc_yuyv2rgb(): a trailing partial group of 8 is not converted. */
+  if ((size_t)in->width * in->height % 8 != 0)
+    UVC_DEBUG("%ux%u is not a multiple of 8 pixels, %zu trailing pixel(s) "
+              "left unconverted", in->width, in->height,
+              (size_t)in->width * in->height % 8);
 
   /* See uvc_yuyv2rgb(): the end comes from the geometry, not data_bytes. */
   uint8_t *pbgr_end = pbgr + (size_t)in->width * in->height / 8 * (3 * 8);
@@ -398,6 +411,12 @@ uvc_error_t uvc_uyvy2rgb(uvc_frame_t *in, uvc_frame_t *out) {
   uint8_t *pyuv = in->data;
   uint8_t *prgb = out->data;
 
+  /* See uvc_yuyv2rgb(): a trailing partial group of 8 is not converted. */
+  if ((size_t)in->width * in->height % 8 != 0)
+    UVC_DEBUG("%ux%u is not a multiple of 8 pixels, %zu trailing pixel(s) "
+              "left unconverted", in->width, in->height,
+              (size_t)in->width * in->height % 8);
+
   /* See uvc_yuyv2rgb(): the end comes from the geometry, not data_bytes. */
   uint8_t *prgb_end = prgb + (size_t)in->width * in->height / 8 * (3 * 8);
 
@@ -452,6 +471,12 @@ uvc_error_t uvc_uyvy2bgr(uvc_frame_t *in, uvc_frame_t *out) {
 
   uint8_t *pyuv = in->data;
   uint8_t *pbgr = out->data;
+
+  /* See uvc_yuyv2rgb(): a trailing partial group of 8 is not converted. */
+  if ((size_t)in->width * in->height % 8 != 0)
+    UVC_DEBUG("%ux%u is not a multiple of 8 pixels, %zu trailing pixel(s) "
+              "left unconverted", in->width, in->height,
+              (size_t)in->width * in->height % 8);
 
   /* See uvc_yuyv2rgb(): the end comes from the geometry, not data_bytes. */
   uint8_t *pbgr_end = pbgr + (size_t)in->width * in->height / 8 * (3 * 8);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Unit tests. Opt-in via BUILD_TESTING, so a plain `cmake ..` still needs
+# nothing but a C compiler and libusb.
+
+enable_language(CXX)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(GTest REQUIRED)
+include(GoogleTest)
+
+if(NOT TARGET uvc_static)
+  message(FATAL_ERROR
+    "Tests need the static library. Configure with "
+    "-DCMAKE_BUILD_TARGET=Both (the default) or Static.")
+endif()
+
+add_executable(test_frame test_frame.cc)
+target_link_libraries(test_frame PRIVATE uvc_static GTest::gtest_main)
+
+gtest_discover_tests(test_frame
+  DISCOVERY_TIMEOUT 30
+  PROPERTIES TIMEOUT 60
+)

--- a/test/test_frame.cc
+++ b/test/test_frame.cc
@@ -1,0 +1,274 @@
+/** @file test_frame.cc
+ * @brief Unit tests for the pixel format converters in src/frame.c.
+ *
+ * A frame's width and height come from the negotiated format, but data_bytes
+ * is however much the camera actually sent, so a truncated transfer leaves
+ * the two inconsistent. A converter bounding its loop on the output buffer
+ * rather than the input geometry then reads past the end of the input.
+ *
+ * Run these with -DENABLE_SANITIZERS=ON: without one, the overflow cases
+ * read stale heap memory and appear to pass.
+ */
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+#include "libuvc/libuvc.h"
+
+namespace {
+
+/* ---------------------------------------------------------------- helpers */
+
+/** Run @p body in a forked child and require a clean exit, so that one
+ * sanitizer abort does not take the rest of the matrix with it. */
+#define EXPECT_MEMORY_SAFE(body) \
+  EXPECT_EXIT({ body; _exit(0); }, ::testing::ExitedWithCode(0), "")
+
+/** Assert inside an EXPECT_MEMORY_SAFE body. GoogleTest's macros do not work
+ * here: ASSERT_* expands to a return, which EXPECT_EXIT rejects, and EXPECT_*
+ * failures die with the child. Only the exit status crosses back. */
+#define REQUIRE_IN_CHILD(cond) \
+  do { \
+    if (!(cond)) { \
+      std::fprintf(stderr, "REQUIRE_IN_CHILD failed: %s at %s:%d\n", \
+                   #cond, __FILE__, __LINE__); \
+      _exit(1); \
+    } \
+  } while (0)
+
+
+struct FrameDeleter {
+  void operator()(uvc_frame_t *f) const { if (f) uvc_free_frame(f); }
+};
+using FramePtr = std::unique_ptr<uvc_frame_t, FrameDeleter>;
+
+/** Allocate a library-owned frame of exactly @p bytes, so a redzone sits
+ * right after the data and a one-byte overread is caught.
+ *
+ * The contents only need to be deterministic and non-uniform: these frames
+ * drive the bounds-checking tests, and what the converters compute from them
+ * is checked against the reference images instead. */
+FramePtr MakeFrame(uvc_frame_format fmt, uint32_t width, uint32_t height,
+                   size_t bytes) {
+  FramePtr f(uvc_allocate_frame(bytes));
+  if (!f) return f;
+
+  f->width = width;
+  f->height = height;
+  f->frame_format = fmt;
+  f->step = 0;
+
+  auto *p = static_cast<uint8_t *>(f->data);
+  for (size_t i = 0; i < bytes; ++i)
+    p[i] = static_cast<uint8_t>(i * 7 + 13);
+
+  return f;
+}
+
+/** An output frame whose buffer the caller owns. uvc_ensure_frame_size()
+ * only rejects a too-small caller buffer, leaving data_bytes at the caller's
+ * larger value, so a bound taken from it overshoots the geometry. */
+struct CallerOwnedFrame {
+  uvc_frame_t frame{};
+  std::vector<uint8_t> storage;
+
+  CallerOwnedFrame(uvc_frame_format fmt, size_t bytes) : storage(bytes, 0) {
+    frame.data = storage.data();
+    frame.data_bytes = bytes;
+    frame.library_owns_data = 0;
+    frame.frame_format = fmt;
+  }
+};
+
+/** The converters under test, named so failures identify themselves. */
+struct Converter {
+  const char *name;
+  uvc_error_t (*fn)(uvc_frame_t *, uvc_frame_t *);
+  uvc_frame_format in_format;
+  /** Output bytes per pixel, for sizing the destination. */
+  int out_bpp;
+};
+
+const Converter kConverters[] = {
+  { "uvc_yuyv2rgb", uvc_yuyv2rgb, UVC_FRAME_FORMAT_YUYV, 3 },
+  { "uvc_yuyv2bgr", uvc_yuyv2bgr, UVC_FRAME_FORMAT_YUYV, 3 },
+  { "uvc_yuyv2y",   uvc_yuyv2y,   UVC_FRAME_FORMAT_YUYV, 1 },
+  { "uvc_yuyv2uv",  uvc_yuyv2uv,  UVC_FRAME_FORMAT_YUYV, 1 },
+  { "uvc_uyvy2rgb", uvc_uyvy2rgb, UVC_FRAME_FORMAT_UYVY, 3 },
+  { "uvc_uyvy2bgr", uvc_uyvy2bgr, UVC_FRAME_FORMAT_UYVY, 3 },
+};
+
+struct Geometry {
+  uint32_t width, height;
+};
+
+/* Resolutions taken from the descriptor dumps in cameras/. */
+const Geometry kGeometries[] = {
+  {160, 120}, {320, 240}, {640, 480}, {1280, 720},
+};
+
+std::ostream &operator<<(std::ostream &os, const Geometry &g) {
+  return os << g.width << "x" << g.height;
+}
+
+/* ------------------------------------------------------- converter matrix */
+
+class ConverterTest
+    : public ::testing::TestWithParam<std::tuple<Converter, Geometry>> {
+ protected:
+  const Converter &conv() const { return std::get<0>(GetParam()); }
+  const Geometry &geom() const { return std::get<1>(GetParam()); }
+
+  size_t InBytes() const {
+    return static_cast<size_t>(geom().width) * geom().height * 2;
+  }
+  size_t OutBytes() const {
+    return static_cast<size_t>(geom().width) * geom().height * conv().out_bpp;
+  }
+};
+
+std::string ParamName(
+    const ::testing::TestParamInfo<ConverterTest::ParamType> &info) {
+  const auto &c = std::get<0>(info.param);
+  const auto &g = std::get<1>(info.param);
+  return std::string(c.name) + "_" + std::to_string(g.width) + "x" +
+         std::to_string(g.height);
+}
+
+/** Baseline: the hardening must not start rejecting valid input. */
+TEST_P(ConverterTest, ValidFrameSucceeds) {
+  const Converter c = conv();
+  const Geometry g = geom();
+  const size_t in_bytes = InBytes();
+
+  EXPECT_MEMORY_SAFE({
+    auto in = MakeFrame(c.in_format, g.width, g.height, in_bytes);
+    REQUIRE_IN_CHILD(in != nullptr);
+    FramePtr out(uvc_allocate_frame(0));
+    REQUIRE_IN_CHILD(out != nullptr);
+
+    REQUIRE_IN_CHILD(c.fn(in.get(), out.get()) == UVC_SUCCESS);
+    REQUIRE_IN_CHILD(out->width == g.width);
+    REQUIRE_IN_CHILD(out->height == g.height);
+  }) << c.name << " on a valid " << g << " frame";
+}
+
+/* Regression test for libuvc/libuvc#211: an input one byte short of what
+ * width * height implies, as a truncated USB transfer produces. */
+TEST_P(ConverterTest, ShortInputRejected) {
+  const size_t full = InBytes();
+
+  const Converter c = conv();
+  const Geometry g = geom();
+
+  EXPECT_MEMORY_SAFE({
+    auto in = MakeFrame(c.in_format, g.width, g.height, full - 1);
+    REQUIRE_IN_CHILD(in != nullptr);
+    FramePtr out(uvc_allocate_frame(0));
+    REQUIRE_IN_CHILD(out != nullptr);
+    REQUIRE_IN_CHILD(c.fn(in.get(), out.get()) != UVC_SUCCESS);
+  }) << c.name << " on a frame " << (full - 1) << " bytes long for a "
+     << g << " image needing " << full;
+}
+
+/** A drastically truncated frame. */
+TEST_P(ConverterTest, SingleByteInputRejected) {
+  const Converter c = conv();
+  const Geometry g = geom();
+
+  EXPECT_MEMORY_SAFE({
+    auto in = MakeFrame(c.in_format, g.width, g.height, 1);
+    REQUIRE_IN_CHILD(in != nullptr);
+    FramePtr out(uvc_allocate_frame(0));
+    REQUIRE_IN_CHILD(out != nullptr);
+    REQUIRE_IN_CHILD(c.fn(in.get(), out.get()) != UVC_SUCCESS);
+  }) << c.name;
+}
+
+/** An empty frame must be rejected, not dereferenced. */
+TEST_P(ConverterTest, EmptyInputRejected) {
+  const Converter c = conv();
+  const Geometry g = geom();
+
+  EXPECT_MEMORY_SAFE({
+    auto in = MakeFrame(c.in_format, g.width, g.height, 0);
+    REQUIRE_IN_CHILD(in != nullptr);
+    FramePtr out(uvc_allocate_frame(0));
+    REQUIRE_IN_CHILD(out != nullptr);
+    REQUIRE_IN_CHILD(c.fn(in.get(), out.get()) != UVC_SUCCESS);
+  }) << c.name;
+}
+
+/* An oversized caller-owned output must not make the converter read past a
+ * correctly sized input. */
+TEST_P(ConverterTest, OversizedCallerOwnedOutputDoesNotOverreadInput) {
+  const Converter c = conv();
+  const Geometry g = geom();
+  const size_t in_bytes = InBytes();
+  const size_t out_bytes = OutBytes();
+
+  EXPECT_MEMORY_SAFE({
+    auto in = MakeFrame(c.in_format, g.width, g.height, in_bytes);
+    REQUIRE_IN_CHILD(in != nullptr);
+
+    /* Well over what the frame needs, so a data_bytes bound overshoots. */
+    CallerOwnedFrame out(UVC_FRAME_FORMAT_RGB, out_bytes * 4 + 3 * 8);
+
+    REQUIRE_IN_CHILD(c.fn(in.get(), &out.frame) == UVC_SUCCESS);
+  }) << c.name;
+}
+
+/** An input frame whose format does not match must be rejected. */
+TEST_P(ConverterTest, WrongInputFormatRejected) {
+  auto in = MakeFrame(UVC_FRAME_FORMAT_GRAY8, geom().width, geom().height,
+                      InBytes());
+  ASSERT_NE(in, nullptr);
+  FramePtr out(uvc_allocate_frame(0));
+  ASSERT_NE(out, nullptr);
+
+  EXPECT_EQ(conv().fn(in.get(), out.get()), UVC_ERROR_INVALID_PARAM);
+}
+
+/** A too-small caller-owned output must be refused, not written past. */
+TEST_P(ConverterTest, UndersizedCallerOwnedOutputRejected) {
+  auto in = MakeFrame(conv().in_format, geom().width, geom().height, InBytes());
+  ASSERT_NE(in, nullptr);
+
+  CallerOwnedFrame out(UVC_FRAME_FORMAT_RGB, OutBytes() - 1);
+
+  EXPECT_NE(conv().fn(in.get(), &out.frame), UVC_SUCCESS);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Converters, ConverterTest,
+    ::testing::Combine(::testing::ValuesIn(kConverters),
+                       ::testing::ValuesIn(kGeometries)),
+    ParamName);
+
+/** An unsupported format must be refused, not passed to a converter. */
+TEST(FrameConversion, AnyToRgbRejectsUnsupportedFormat) {
+  EXPECT_MEMORY_SAFE({
+    auto in = MakeFrame(UVC_FRAME_FORMAT_UNKNOWN, 32, 32, 32 * 32 * 2);
+    REQUIRE_IN_CHILD(in != nullptr);
+    FramePtr out(uvc_allocate_frame(0));
+    REQUIRE_IN_CHILD(out != nullptr);
+    REQUIRE_IN_CHILD(uvc_any2rgb(in.get(), out.get()) != UVC_SUCCESS);
+    REQUIRE_IN_CHILD(uvc_any2bgr(in.get(), out.get()) != UVC_SUCCESS);
+  });
+}
+
+/** A short frame must not make uvc_duplicate_frame read the geometry's
+ * worth instead of data_bytes. */
+TEST(FrameConversion, DuplicateShortFrameStaysInBounds) {
+  EXPECT_MEMORY_SAFE({
+    auto in = MakeFrame(UVC_FRAME_FORMAT_YUYV, 64, 32, 64);  /* far too short */
+    REQUIRE_IN_CHILD(in != nullptr);
+    FramePtr out(uvc_allocate_frame(0));
+    REQUIRE_IN_CHILD(out != nullptr);
+    (void)uvc_duplicate_frame(in.get(), out.get());
+  });
+}
+
+}  // namespace

--- a/test/test_frame.cc
+++ b/test/test_frame.cc
@@ -7,11 +7,11 @@
  * rather than the input geometry then reads past the end of the input.
  *
  * Run these with -DENABLE_SANITIZERS=ON: without one, the overflow cases
- * read stale heap memory and appear to pass.
+ * read stale heap memory and appear to pass. An overread aborts the test
+ * binary, which is the failure signal -- ctest reports the case that died.
  */
 #include <gtest/gtest.h>
 
-#include <cstdio>
 #include <memory>
 #include <vector>
 
@@ -20,24 +20,6 @@
 namespace {
 
 /* ---------------------------------------------------------------- helpers */
-
-/** Run @p body in a forked child and require a clean exit, so that one
- * sanitizer abort does not take the rest of the matrix with it. */
-#define EXPECT_MEMORY_SAFE(body) \
-  EXPECT_EXIT({ body; _exit(0); }, ::testing::ExitedWithCode(0), "")
-
-/** Assert inside an EXPECT_MEMORY_SAFE body. GoogleTest's macros do not work
- * here: ASSERT_* expands to a return, which EXPECT_EXIT rejects, and EXPECT_*
- * failures die with the child. Only the exit status crosses back. */
-#define REQUIRE_IN_CHILD(cond) \
-  do { \
-    if (!(cond)) { \
-      std::fprintf(stderr, "REQUIRE_IN_CHILD failed: %s at %s:%d\n", \
-                   #cond, __FILE__, __LINE__); \
-      _exit(1); \
-    } \
-  } while (0)
-
 
 struct FrameDeleter {
   void operator()(uvc_frame_t *f) const { if (f) uvc_free_frame(f); }
@@ -139,20 +121,14 @@ std::string ParamName(
 
 /** Baseline: the hardening must not start rejecting valid input. */
 TEST_P(ConverterTest, ValidFrameSucceeds) {
-  const Converter c = conv();
-  const Geometry g = geom();
-  const size_t in_bytes = InBytes();
+  auto in = MakeFrame(conv().in_format, geom().width, geom().height, InBytes());
+  ASSERT_NE(in, nullptr);
+  FramePtr out(uvc_allocate_frame(0));
+  ASSERT_NE(out, nullptr);
 
-  EXPECT_MEMORY_SAFE({
-    auto in = MakeFrame(c.in_format, g.width, g.height, in_bytes);
-    REQUIRE_IN_CHILD(in != nullptr);
-    FramePtr out(uvc_allocate_frame(0));
-    REQUIRE_IN_CHILD(out != nullptr);
-
-    REQUIRE_IN_CHILD(c.fn(in.get(), out.get()) == UVC_SUCCESS);
-    REQUIRE_IN_CHILD(out->width == g.width);
-    REQUIRE_IN_CHILD(out->height == g.height);
-  }) << c.name << " on a valid " << g << " frame";
+  ASSERT_EQ(conv().fn(in.get(), out.get()), UVC_SUCCESS);
+  EXPECT_EQ(out->width, geom().width);
+  EXPECT_EQ(out->height, geom().height);
 }
 
 /* Regression test for libuvc/libuvc#211: an input one byte short of what
@@ -160,64 +136,46 @@ TEST_P(ConverterTest, ValidFrameSucceeds) {
 TEST_P(ConverterTest, ShortInputRejected) {
   const size_t full = InBytes();
 
-  const Converter c = conv();
-  const Geometry g = geom();
+  auto in = MakeFrame(conv().in_format, geom().width, geom().height, full - 1);
+  ASSERT_NE(in, nullptr);
+  FramePtr out(uvc_allocate_frame(0));
+  ASSERT_NE(out, nullptr);
 
-  EXPECT_MEMORY_SAFE({
-    auto in = MakeFrame(c.in_format, g.width, g.height, full - 1);
-    REQUIRE_IN_CHILD(in != nullptr);
-    FramePtr out(uvc_allocate_frame(0));
-    REQUIRE_IN_CHILD(out != nullptr);
-    REQUIRE_IN_CHILD(c.fn(in.get(), out.get()) != UVC_SUCCESS);
-  }) << c.name << " on a frame " << (full - 1) << " bytes long for a "
-     << g << " image needing " << full;
+  EXPECT_NE(conv().fn(in.get(), out.get()), UVC_SUCCESS)
+      << conv().name << " accepted a frame " << (full - 1)
+      << " bytes long for a " << geom() << " image needing " << full;
 }
 
 /** A drastically truncated frame. */
 TEST_P(ConverterTest, SingleByteInputRejected) {
-  const Converter c = conv();
-  const Geometry g = geom();
+  auto in = MakeFrame(conv().in_format, geom().width, geom().height, 1);
+  ASSERT_NE(in, nullptr);
+  FramePtr out(uvc_allocate_frame(0));
+  ASSERT_NE(out, nullptr);
 
-  EXPECT_MEMORY_SAFE({
-    auto in = MakeFrame(c.in_format, g.width, g.height, 1);
-    REQUIRE_IN_CHILD(in != nullptr);
-    FramePtr out(uvc_allocate_frame(0));
-    REQUIRE_IN_CHILD(out != nullptr);
-    REQUIRE_IN_CHILD(c.fn(in.get(), out.get()) != UVC_SUCCESS);
-  }) << c.name;
+  EXPECT_NE(conv().fn(in.get(), out.get()), UVC_SUCCESS);
 }
 
 /** An empty frame must be rejected, not dereferenced. */
 TEST_P(ConverterTest, EmptyInputRejected) {
-  const Converter c = conv();
-  const Geometry g = geom();
+  auto in = MakeFrame(conv().in_format, geom().width, geom().height, 0);
+  ASSERT_NE(in, nullptr);
+  FramePtr out(uvc_allocate_frame(0));
+  ASSERT_NE(out, nullptr);
 
-  EXPECT_MEMORY_SAFE({
-    auto in = MakeFrame(c.in_format, g.width, g.height, 0);
-    REQUIRE_IN_CHILD(in != nullptr);
-    FramePtr out(uvc_allocate_frame(0));
-    REQUIRE_IN_CHILD(out != nullptr);
-    REQUIRE_IN_CHILD(c.fn(in.get(), out.get()) != UVC_SUCCESS);
-  }) << c.name;
+  EXPECT_NE(conv().fn(in.get(), out.get()), UVC_SUCCESS);
 }
 
 /* An oversized caller-owned output must not make the converter read past a
  * correctly sized input. */
 TEST_P(ConverterTest, OversizedCallerOwnedOutputDoesNotOverreadInput) {
-  const Converter c = conv();
-  const Geometry g = geom();
-  const size_t in_bytes = InBytes();
-  const size_t out_bytes = OutBytes();
+  auto in = MakeFrame(conv().in_format, geom().width, geom().height, InBytes());
+  ASSERT_NE(in, nullptr);
 
-  EXPECT_MEMORY_SAFE({
-    auto in = MakeFrame(c.in_format, g.width, g.height, in_bytes);
-    REQUIRE_IN_CHILD(in != nullptr);
+  /* Well over what the frame needs, so a data_bytes bound overshoots. */
+  CallerOwnedFrame out(UVC_FRAME_FORMAT_RGB, OutBytes() * 4 + 3 * 8);
 
-    /* Well over what the frame needs, so a data_bytes bound overshoots. */
-    CallerOwnedFrame out(UVC_FRAME_FORMAT_RGB, out_bytes * 4 + 3 * 8);
-
-    REQUIRE_IN_CHILD(c.fn(in.get(), &out.frame) == UVC_SUCCESS);
-  }) << c.name;
+  EXPECT_EQ(conv().fn(in.get(), &out.frame), UVC_SUCCESS);
 }
 
 /** An input frame whose format does not match must be rejected. */
@@ -249,26 +207,24 @@ INSTANTIATE_TEST_SUITE_P(
 
 /** An unsupported format must be refused, not passed to a converter. */
 TEST(FrameConversion, AnyToRgbRejectsUnsupportedFormat) {
-  EXPECT_MEMORY_SAFE({
-    auto in = MakeFrame(UVC_FRAME_FORMAT_UNKNOWN, 32, 32, 32 * 32 * 2);
-    REQUIRE_IN_CHILD(in != nullptr);
-    FramePtr out(uvc_allocate_frame(0));
-    REQUIRE_IN_CHILD(out != nullptr);
-    REQUIRE_IN_CHILD(uvc_any2rgb(in.get(), out.get()) != UVC_SUCCESS);
-    REQUIRE_IN_CHILD(uvc_any2bgr(in.get(), out.get()) != UVC_SUCCESS);
-  });
+  auto in = MakeFrame(UVC_FRAME_FORMAT_UNKNOWN, 32, 32, 32 * 32 * 2);
+  ASSERT_NE(in, nullptr);
+  FramePtr out(uvc_allocate_frame(0));
+  ASSERT_NE(out, nullptr);
+
+  EXPECT_NE(uvc_any2rgb(in.get(), out.get()), UVC_SUCCESS);
+  EXPECT_NE(uvc_any2bgr(in.get(), out.get()), UVC_SUCCESS);
 }
 
 /** A short frame must not make uvc_duplicate_frame read the geometry's
  * worth instead of data_bytes. */
 TEST(FrameConversion, DuplicateShortFrameStaysInBounds) {
-  EXPECT_MEMORY_SAFE({
-    auto in = MakeFrame(UVC_FRAME_FORMAT_YUYV, 64, 32, 64);  /* far too short */
-    REQUIRE_IN_CHILD(in != nullptr);
-    FramePtr out(uvc_allocate_frame(0));
-    REQUIRE_IN_CHILD(out != nullptr);
-    (void)uvc_duplicate_frame(in.get(), out.get());
-  });
+  auto in = MakeFrame(UVC_FRAME_FORMAT_YUYV, 64, 32, 64);  /* far too short */
+  ASSERT_NE(in, nullptr);
+  FramePtr out(uvc_allocate_frame(0));
+  ASSERT_NE(out, nullptr);
+
+  (void)uvc_duplicate_frame(in.get(), out.get());
 }
 
 }  // namespace


### PR DESCRIPTION
Stacks on top of #304.

The test framework is semi-vibe-coded, I'll do another pass of review but I think it's ok. It's not production code, it detects issues, so that's already better than what we have currently (which is basically nothing).

Then I pick up the fix in #211, with another layer of changes after thinking about this a bit more.