### PR TITLE
[code] add possibility to have custom log function (revive #253)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,16 @@ jobs:
         compiler: [ gcc, clang ]
         target: [ Both, Shared, Static ]
         jpeg: [ on, off ]
+        debugging: [ off ]
+        # ENABLE_UVC_DEBUGGING is off by default, so nothing above compiles
+        # the UVC_DEBUGGING code paths. One variant is enough to cover them.
+        include:
+          - compiler: gcc
+            target: Both
+            jpeg: on
+            debugging: on
 
-    name: ${{ matrix.compiler }}, ${{ matrix.target }}${{ matrix.jpeg == 'off' && ', no jpeg' || '' }}
+    name: ${{ matrix.compiler }}, ${{ matrix.target }}${{ matrix.jpeg == 'off' && ', no jpeg' || '' }}${{ matrix.debugging == 'on' && ', uvc debugging' || '' }}
 
     steps:
       - uses: actions/checkout@v5
@@ -44,7 +52,8 @@ jobs:
             -DLibUVC_STATIC=${{ matrix.target == 'Static' && 'ON' || 'OFF' }} \
             -DBUILD_EXAMPLE=ON \
             -DDISABLE_JPEG=${{ matrix.jpeg == 'off' && 'ON' || 'OFF' }} \
-            -DWARNINGS_AS_ERRORS=ON
+            -DWARNINGS_AS_ERRORS=ON \
+            -DENABLE_UVC_DEBUGGING=${{ matrix.debugging == 'on' && 'ON' || 'OFF' }}
 
       - name: Build
         run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,15 +151,12 @@ foreach(target_name IN LISTS UVC_TARGETS)
       PRIVATE
         UVC_DEBUGGING
     )
-    find_library(
-            log-lib
-            log
-    )
-    target_link_libraries(
-            ${target_name}
-            PRIVATE
-            ${log-lib}
-    )
+    if(ANDROID)
+      find_library(log-lib log REQUIRED)
+      target_link_libraries(${target_name}
+        PRIVATE ${log-lib}
+      )
+    endif()
   endif()
 endforeach()
 

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -807,9 +807,13 @@ uvc_error_t uvc_mjpeg2gray(uvc_frame_t *in, uvc_frame_t *out);
 #endif
 
 
-typedef void (uvc_log_func_t)(const char *filename, unsigned line, const char *function, const char *log);
+typedef void (*uvc_log_func_t)(const char *filename, unsigned line, const char *function, const char *log);
 void uvc_log_set_function(uvc_log_func_t func);
-void uvc_log(char *filename, unsigned line, const char *function, const char *format, ...);
+void uvc_log(const char *filename, unsigned line, const char *function, const char *format, ...)
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((format(printf, 4, 5)))
+#endif
+    ;
 
 #ifdef __cplusplus
 }

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -806,9 +806,13 @@ uvc_error_t uvc_mjpeg2rgb(uvc_frame_t *in, uvc_frame_t *out);
 uvc_error_t uvc_mjpeg2gray(uvc_frame_t *in, uvc_frame_t *out);
 #endif
 
+
+typedef void (uvc_log_func_t)(const char *filename, unsigned line, const char *function, const char *log);
+void uvc_log_set_function(uvc_log_func_t func);
+void uvc_log(char *filename, unsigned line, const char *function, const char *format, ...);
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif // !def(LIBUVC_H)
-

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -50,20 +50,12 @@
 
 #ifdef UVC_DEBUGGING
 #include <libgen.h>
-#ifdef __ANDROID__
-#include <android/log.h>
-#define UVC_DEBUG(format, ...) __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d/%s] " format "\n", basename(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__)
-#define UVC_ENTER() __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d] begin %s\n", basename(__FILE__), __LINE__, __FUNCTION__)
-#define UVC_EXIT(code) __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d] end %s (%d)\n", basename(__FILE__), __LINE__, __FUNCTION__, code)
-#define UVC_EXIT_VOID() __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d] end %s\n", basename(__FILE__), __LINE__, __FUNCTION__)
+#define UVC_DEBUG(...)  uvc_log(__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define UVC_ENTER()     uvc_log(__FILE__, __LINE__, __FUNCTION__, "Entering")
+#define UVC_EXIT(code)  uvc_log(__FILE__, __LINE__, __FUNCTION__, "Ending: %d", code)
+#define UVC_EXIT_VOID() uvc_log(__FILE__, __LINE__, __FUNCTION__, "Ending")
 #else
-#define UVC_DEBUG(format, ...) fprintf(stderr, "[%s:%d/%s] " format "\n", basename(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__)
-#define UVC_ENTER() fprintf(stderr, "[%s:%d] begin %s\n", basename(__FILE__), __LINE__, __FUNCTION__)
-#define UVC_EXIT(code) fprintf(stderr, "[%s:%d] end %s (%d)\n", basename(__FILE__), __LINE__, __FUNCTION__, code)
-#define UVC_EXIT_VOID() fprintf(stderr, "[%s:%d] end %s\n", basename(__FILE__), __LINE__, __FUNCTION__)
-#endif
-#else
-#define UVC_DEBUG(format, ...)
+#define UVC_DEBUG(...)
 #define UVC_ENTER()
 #define UVC_EXIT_VOID()
 #define UVC_EXIT(code)
@@ -317,4 +309,3 @@ uvc_error_t uvc_release_if(uvc_device_handle_t *devh, int idx);
 
 #endif // !def(LIBUVC_INTERNAL_H)
 /** @endcond */
-

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -49,7 +49,6 @@
   } while (0);
 
 #ifdef UVC_DEBUGGING
-#include <libgen.h>
 #define UVC_DEBUG(...)  uvc_log(__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
 #define UVC_ENTER()     uvc_log(__FILE__, __LINE__, __FUNCTION__, "Entering")
 #define UVC_EXIT(code)  uvc_log(__FILE__, __LINE__, __FUNCTION__, "Ending: %d", code)

--- a/src/init.c
+++ b/src/init.c
@@ -70,6 +70,12 @@ YUV stream from a UVC device such as a standard webcam.
 \include example.c
 
 */
+#include <stdarg.h>
+#include <libgen.h>
+
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
 
 /**
  * @defgroup init Library initialization/deinitialization
@@ -161,3 +167,27 @@ void uvc_start_handler_thread(uvc_context_t *ctx) {
     pthread_create(&ctx->handler_thread, NULL, _uvc_handle_events, (void*) ctx);
 }
 
+
+static uvc_log_func_t *uvc_log_func = NULL;
+#define UVC_LOG_LINE_MAX_LEN 1024
+void uvc_log_set_function(uvc_log_func_t func) {
+    uvc_log_func = func;
+}
+
+void uvc_log(char *filename, unsigned line, const char *function, const char *format, ...) {
+    char buf_line[UVC_LOG_LINE_MAX_LEN] = {0};
+
+    va_list org;
+    va_start(org, format);
+    vsnprintf(buf_line, sizeof(buf_line), format, org);
+    if (uvc_log_func) {
+      (*uvc_log_func)(filename, line, function, buf_line);
+    } else {
+      #ifdef __ANDROID__
+        __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d] %s - %s\n", basename(filename), line, function, buf_line);
+      #else
+        fprintf(stderr, "[%s:%d] %s - %s\n", basename(filename), line, function, buf_line);
+      #endif
+    }
+    va_end(org);
+}

--- a/src/init.c
+++ b/src/init.c
@@ -71,7 +71,7 @@ YUV stream from a UVC device such as a standard webcam.
 
 */
 #include <stdarg.h>
-#include <libgen.h>
+#include <string.h>
 
 #ifdef __ANDROID__
 #include <android/log.h>
@@ -168,26 +168,40 @@ void uvc_start_handler_thread(uvc_context_t *ctx) {
 }
 
 
-static uvc_log_func_t *uvc_log_func = NULL;
+static uvc_log_func_t uvc_log_func = NULL;
+
 #define UVC_LOG_LINE_MAX_LEN 1024
+
 void uvc_log_set_function(uvc_log_func_t func) {
-    uvc_log_func = func;
+  uvc_log_func = func;
 }
 
-void uvc_log(char *filename, unsigned line, const char *function, const char *format, ...) {
-    char buf_line[UVC_LOG_LINE_MAX_LEN] = {0};
+void uvc_log(const char *filename, unsigned line, const char *function, const char *format, ...) {
+  char buf_line[UVC_LOG_LINE_MAX_LEN];
+  const char *base;
+  va_list args;
 
-    va_list org;
-    va_start(org, format);
-    vsnprintf(buf_line, sizeof(buf_line), format, org);
-    if (uvc_log_func) {
-      (*uvc_log_func)(filename, line, function, buf_line);
-    } else {
-      #ifdef __ANDROID__
-        __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%d] %s - %s\n", basename(filename), line, function, buf_line);
-      #else
-        fprintf(stderr, "[%s:%d] %s - %s\n", basename(filename), line, function, buf_line);
-      #endif
-    }
-    va_end(org);
+  va_start(args, format);
+  vsnprintf(buf_line, sizeof(buf_line), format, args);
+  va_end(args);
+
+  if (uvc_log_func) {
+    uvc_log_func(filename, line, function, buf_line);
+    return;
+  }
+
+  /* Not basename(): the one from <libgen.h> is the POSIX version, which is
+   * allowed to modify its argument, and filename is __FILE__. The GNU
+   * version is const-correct but needs _GNU_SOURCE and glibc, so it is not
+   * available on musl, macOS or bionic. */
+  base = strrchr(filename, '/');
+  base = base ? base + 1 : filename;
+
+#ifdef __ANDROID__
+  __android_log_print(ANDROID_LOG_DEBUG, "libuvc", "[%s:%u] %s - %s\n",
+                      base, line, function, buf_line);
+#else
+  fprintf(stderr, "[%s:%u] %s - %s\n",
+          base, line, function, buf_line);
+#endif
 }


### PR DESCRIPTION
> For debugging purposes, it can be nice to be able to set up a custom logging function.
> If not set, it returns to current behaviour, and print outputs to stderr or logcat

Also, `basename` is _technically_ incorrect to call if it's the POSIX implementation.

And add CI, looks like this was broken all along on non-Android.