### PR TITLE
Fix UVC version information (bcdUVC never filled up, add accessor function)

### DIFF
--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -441,7 +441,7 @@ typedef struct uvc_device_descriptor {
   uint16_t idProduct;
   /** Reserved; was bcdUVC, which was never populated (always read 0).
    * Kept to preserve the layout of the fields below.
-   * Use uvc_get_uvc_compliance() on an open handle instead. */
+   * Use uvc_get_spec_version() on an open handle instead. */
   uint16_t reserved;
   /** Serial number (null if unavailable) */
   const char *serialNumber;
@@ -590,7 +590,7 @@ const uvc_output_terminal_t *uvc_get_output_terminals(uvc_device_handle_t *devh)
 const uvc_selector_unit_t *uvc_get_selector_units(uvc_device_handle_t *devh);
 const uvc_processing_unit_t *uvc_get_processing_units(uvc_device_handle_t *devh);
 const uvc_extension_unit_t *uvc_get_extension_units(uvc_device_handle_t *devh);
-uint16_t uvc_get_uvc_compliance(uvc_device_handle_t *devh);
+uint16_t uvc_get_spec_version(uvc_device_handle_t *devh);
 
 uvc_error_t uvc_get_stream_ctrl_format_size(
     uvc_device_handle_t *devh,

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -588,6 +588,7 @@ const uvc_output_terminal_t *uvc_get_output_terminals(uvc_device_handle_t *devh)
 const uvc_selector_unit_t *uvc_get_selector_units(uvc_device_handle_t *devh);
 const uvc_processing_unit_t *uvc_get_processing_units(uvc_device_handle_t *devh);
 const uvc_extension_unit_t *uvc_get_extension_units(uvc_device_handle_t *devh);
+uint16_t uvc_get_uvc_compliance(uvc_device_handle_t *devh);
 
 uvc_error_t uvc_get_stream_ctrl_format_size(
     uvc_device_handle_t *devh,

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -439,8 +439,10 @@ typedef struct uvc_device_descriptor {
   uint16_t idVendor;
   /** Product ID */
   uint16_t idProduct;
-  /** UVC compliance level, e.g. 0x0100 (1.0), 0x0110 */
-  uint16_t bcdUVC;
+  /** Reserved; was bcdUVC, which was never populated (always read 0).
+   * Kept to preserve the layout of the fields below.
+   * Use uvc_get_uvc_compliance() on an open handle instead. */
+  uint16_t reserved;
   /** Serial number (null if unavailable) */
   const char *serialNumber;
   /** Device-reported manufacturer name (or null) */

--- a/src/device.c
+++ b/src/device.c
@@ -546,6 +546,7 @@ static uvc_error_t get_device_descriptor(
     return ret;
   }
 
+  /* calloc: leaves the reserved field zeroed */
   desc_internal = calloc(1, sizeof(*desc_internal));
   desc_internal->idVendor = usb_desc.idVendor;
   desc_internal->idProduct = usb_desc.idProduct;
@@ -604,6 +605,7 @@ uvc_error_t uvc_get_device_descriptor(
     return ret;
   }
 
+  /* calloc: leaves the reserved field zeroed */
   desc_internal = calloc(1, sizeof(*desc_internal));
   desc_internal->idVendor = usb_desc.idVendor;
   desc_internal->idProduct = usb_desc.idProduct;

--- a/src/device.c
+++ b/src/device.c
@@ -929,6 +929,15 @@ const uvc_extension_unit_t *uvc_get_extension_units(uvc_device_handle_t *devh) {
 }
 
 /**
+ * @brief Get compliance to the UVC standard
+ *
+ * @param devh Device handle to an open UVC device
+ */
+uint16_t uvc_get_uvc_compliance(uvc_device_handle_t *devh) {
+  return devh->info->ctrl_if.bcdUVC;
+}
+
+/**
  * @brief Increment the reference count for a device
  * @ingroup device
  *

--- a/src/device.c
+++ b/src/device.c
@@ -931,11 +931,19 @@ const uvc_extension_unit_t *uvc_get_extension_units(uvc_device_handle_t *devh) {
 }
 
 /**
- * @brief Get compliance to the UVC standard
+ * @brief Get the UVC specification version this video function complies with.
+ *
+ * Per the spec, bcdUVC "identifies the release of the Video Device Class
+ * Specification with which this video function and its descriptors are
+ * compliant" -- it describes the video function of the open handle, not the
+ * USB device, which may expose several.
+ *
+ * The value is the bcdUVC field of the VideoControl header, in BCD: 0x0100
+ * for UVC 1.0, 0x010a for 1.0a, 0x0110 for 1.1, 0x0150 for 1.5.
  *
  * @param devh Device handle to an open UVC device
  */
-uint16_t uvc_get_uvc_compliance(uvc_device_handle_t *devh) {
+uint16_t uvc_get_spec_version(uvc_device_handle_t *devh) {
   return devh->info->ctrl_if.bcdUVC;
 }
 


### PR DESCRIPTION
Fixes #238, squashes the 2 commits by @damijans, then:
 - Replace bcdUVC by a reserved field -- probably not a huge deal, but I'd rather not break ABI just yet.
 - Rename function to `uvc_get_spec_version`, which feels _mildly_ better.