### PR TITLE
Handle camera fails to set dwMaxPayloadTransferSize on UVC_GET_MAX (revive #277)

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -280,6 +280,13 @@ uvc_error_t uvc_query_stream_ctrl(
         ctrl->dwMaxVideoFrameSize = frame->dwMaxVideoFrameBufferSize;
       }
     }
+    if (ctrl->dwMaxPayloadTransferSize == 0) {
+      uvc_frame_desc_t *frame = uvc_find_frame_desc(devh, ctrl->bFormatIndex, ctrl->bFrameIndex);
+
+      if (frame) {
+        ctrl->dwMaxPayloadTransferSize = frame->dwMaxBitRate;
+      }
+    }
   }
 
   return UVC_SUCCESS;

--- a/src/stream.c
+++ b/src/stream.c
@@ -281,11 +281,10 @@ uvc_error_t uvc_query_stream_ctrl(
       }
     }
     if (ctrl->dwMaxPayloadTransferSize == 0) {
-      uvc_frame_desc_t *frame = uvc_find_frame_desc(devh, ctrl->bFormatIndex, ctrl->bFrameIndex);
-
-      if (frame) {
-        ctrl->dwMaxPayloadTransferSize = frame->dwMaxBitRate;
-      }
+      /* No per-frame maximum payload size exists in the descriptors, so fall
+       * back on the frame size fixed up above: a payload never needs to be
+       * larger than a whole frame, and both are byte counts. */
+      ctrl->dwMaxPayloadTransferSize = ctrl->dwMaxVideoFrameSize;
     }
   }
 


### PR DESCRIPTION
Pick up the PR #277 by @NoahDorfman00, but using the frame size instead of assigning a bit rate to a transfer size.

I don't have a camera with such behaviour on hand...  I was wondering if this is sufficient to fix the issue, or if we need something along the lines of #292 as well.

@NoahDorfman00, @soonwonjang, @fbzhong, @chelmuth, @fdegaulejac : If any of you have time to test this, it'd be awesome.

